### PR TITLE
#23 Fix: Post 엔티티 변경 이후 Post Create 안 되는 버그 수정

### DIFF
--- a/src/main/java/encore/server/domain/post/converter/PostConverter.java
+++ b/src/main/java/encore/server/domain/post/converter/PostConverter.java
@@ -23,31 +23,24 @@ public class PostConverter {
 
     //PostCreateReq -> Post 로 변환
     public Post convert(PostCreateReq postCreateReq, User user){
-        return new Post(user,
-                postCreateReq.title(),
-                postCreateReq.content(),
-                postCreateReq.isNotice(),
-                postCreateReq.isTemporarySave(),
-                PostType.valueOf(postCreateReq.postType()),
-                Category.valueOf(postCreateReq.category()),
-                new ArrayList<>(),
-                new ArrayList<>()
-        );
+
+        return Post.builder()
+                .user(user)
+                .title(postCreateReq.title())
+                .content(postCreateReq.content())
+                .isNotice(postCreateReq.isNotice())
+                .isTemporarySave(postCreateReq.isTemporarySave())
+                .postType(PostType.valueOf(postCreateReq.postType()))
+                .category(Category.valueOf(postCreateReq.category()))
+                .postHashtags(new ArrayList<>())  // 빈 리스트 초기화
+                .postImages(new ArrayList<>())  // 빈 리스트 초기화
+                .likeCount(0L)
+                .commentCount(0L)
+                .build();
+
     }
 
-    //PostUpdateReq -> Post 로 변환
-    public Post convert(PostUpdateReq postUpdateReq, User user){
-        return new Post(user,
-                postUpdateReq.title(),
-                postUpdateReq.content(),
-                postUpdateReq.isNotice(),
-                postUpdateReq.isTemporarySave(),
-                PostType.valueOf(postUpdateReq.postType()),
-                Category.valueOf(postUpdateReq.category()),
-                new ArrayList<>(),
-                new ArrayList<>()
-        );
-    }
+
 
     public PostDetailsGetRes postDetailsGetResFrom(
             Post post, List<String> hashtags, List<String> postImages, Integer numOfLike, Integer numOfComment

--- a/src/main/java/encore/server/domain/post/entity/Post.java
+++ b/src/main/java/encore/server/domain/post/entity/Post.java
@@ -63,7 +63,8 @@ public class Post extends BaseTimeEntity {
     private Long commentCount;
 
     @Builder
-    public Post(User user, String title, String content,Boolean isNotice, Boolean isTemporarySave, PostType postType, Category category, List<PostHashtag> postHashtags, List<PostImage> postImages) {
+    public Post(User user, String title, String content,Boolean isNotice, Boolean isTemporarySave, PostType postType,
+                Category category, List<PostHashtag> postHashtags, List<PostImage> postImages, Long likeCount, Long commentCount) {
         this.user = user;
         this.title = title;
         this.content = content;
@@ -73,5 +74,7 @@ public class Post extends BaseTimeEntity {
         this.category = category;
         this.postHashtags = postHashtags;
         this.postImages = postImages;
+        this.likeCount = likeCount;
+        this.commentCount = commentCount;
     }
 }

--- a/src/main/java/encore/server/domain/post/enumerate/Category.java
+++ b/src/main/java/encore/server/domain/post/enumerate/Category.java
@@ -15,7 +15,9 @@ public enum Category {
     // 후기 게시판
     VIEW_REVIEW("시야 후기"),
     GOODS_REVIEW("굿즈 후기"),
-    PERFORMANCE_REVIEW("공연 감상 후기");
+    PERFORMANCE_REVIEW("공연 감상 후기"),
+
+    NO_SELECT("카테고리 미선택");
 
     private final String category;
 }

--- a/src/main/java/encore/server/domain/post/enumerate/PostType.java
+++ b/src/main/java/encore/server/domain/post/enumerate/PostType.java
@@ -9,7 +9,9 @@ public enum PostType {
     INFORMATION("정보"),
     REVIEW("후기"),
     FREE("자유"),
-    ACTOR("배우");
+    ACTOR("배우"),
+
+    NO_SELECT("게시글 타입 미선택");
 
     private final String type;
 }

--- a/src/main/java/encore/server/domain/post/service/PostService.java
+++ b/src/main/java/encore/server/domain/post/service/PostService.java
@@ -72,6 +72,7 @@ public class PostService {
         List<String> stringListFromPostHashtag = postHashtagConverter.stringListFrom(allByPost);
         List<String> stringListFromPostImage = postImageConverter.stringListFrom(post.getPostImages());
 
+        //Postlike 에서 Post 의 likeCount를 수정하는 로직이 있나?
         Integer numOfLike = postLikeRepository.countByPostAndDeletedAtIsNull(post);
         Integer numOfComment = commentRepository.countByPostAndDeletedAtIsNull(post);
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #23 

## 📝작업 내용
> likeCount, commentCount 필드가 추가되어 이에 맞게 Post save시 likeCount, commentCount가 0으로 들어갈 수 있도록 변경함. db default가 0으로 되어있지만 적용이 안되는 것 같아서 코드 상으로 수정
