### PR TITLE
Feat, Fix : 티켓북 생성 api 변경/ 배우 검색 api / 티켓북 수정, 삭제 api

### DIFF
--- a/src/main/java/encore/server/domain/musical/controller/MusicalController.java
+++ b/src/main/java/encore/server/domain/musical/controller/MusicalController.java
@@ -23,6 +23,7 @@ import java.util.List;
 public class MusicalController {
     private final MusicalService musicalService;
 
+    @Operation(summary = "뮤지컬 검색", description = "뮤지컬을 키워드로 검색합니다.")
     @GetMapping("/search")
     public ApplicationResponse<List<MusicalRes>> searchMusicals(@RequestParam String keyword) {
         List<MusicalRes> responses = musicalService.searchMusicalsByTitle(keyword);

--- a/src/main/java/encore/server/domain/post/controller/PostController.java
+++ b/src/main/java/encore/server/domain/post/controller/PostController.java
@@ -38,6 +38,7 @@ public class PostController {
     private final PostLikeService postLikeService;
 
     @PostMapping("/likes")
+    @Operation(summary = "게시글 좋아요 API", description = "게시글 좋아요를 누릅니다.")
     public ApplicationResponse<Void> toggleLike(@RequestBody @Valid PostLikeReq postLikeReq) throws Exception {
         postLikeService.toggleLike(postLikeReq);
         return  ApplicationResponse.ok();

--- a/src/main/java/encore/server/domain/ticket/controller/TicketController.java
+++ b/src/main/java/encore/server/domain/ticket/controller/TicketController.java
@@ -4,6 +4,7 @@ package encore.server.domain.ticket.controller;
 
 import encore.server.domain.ticket.dto.request.ActorDTO;
 import encore.server.domain.ticket.dto.request.TicketCreateReq;
+import encore.server.domain.ticket.dto.request.TicketUpdateReq;
 import encore.server.domain.ticket.dto.response.TicketCreateRes;
 import encore.server.domain.ticket.dto.response.TicketRes;
 import encore.server.domain.ticket.service.TicketService;
@@ -47,5 +48,14 @@ public class TicketController {
         return ApplicationResponse.ok(ticketList);
     }
 
+    @Operation(summary = "티켓북 수정", description = "티켓북을 수정합니다.")
+    @PatchMapping("/{ticketId}")
+    public ApplicationResponse<TicketRes> updateTicket(
+            @PathVariable Long ticketId,
+            @RequestBody TicketUpdateReq request
+    ) {
+        TicketRes updatedTicket = ticketService.updateTicket(ticketId, request);
+        return ApplicationResponse.ok(updatedTicket);
+    }
 
 }

--- a/src/main/java/encore/server/domain/ticket/controller/TicketController.java
+++ b/src/main/java/encore/server/domain/ticket/controller/TicketController.java
@@ -5,6 +5,7 @@ package encore.server.domain.ticket.controller;
 import encore.server.domain.ticket.dto.request.ActorDTO;
 import encore.server.domain.ticket.dto.request.TicketCreateReq;
 import encore.server.domain.ticket.dto.response.TicketCreateRes;
+import encore.server.domain.ticket.dto.response.TicketRes;
 import encore.server.domain.ticket.service.TicketService;
 import encore.server.global.common.ApplicationResponse;
 import encore.server.global.exception.ErrorCode;
@@ -12,8 +13,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,11 +26,11 @@ import java.util.List;
 public class TicketController {
     private final TicketService ticketService;
 
-
+    @Operation(summary = "티켓북 생성", description = "티켓북을 생성합니다.")
     @PostMapping
-    public ResponseEntity<TicketCreateRes> createTicket(@RequestBody TicketCreateReq request) {
+    public ApplicationResponse<TicketCreateRes> createTicket(@RequestBody TicketCreateReq request) {
         TicketCreateRes response = ticketService.createTicket(request);
-        return ResponseEntity.ok(response);
+        return ApplicationResponse.created(response);
     }
 
     @Operation(summary = "배우 검색", description = "배우 이름을 키워드로 검색합니다.")
@@ -39,6 +38,13 @@ public class TicketController {
     public ApplicationResponse<List<ActorDTO>> searchActors(@RequestParam String keyword) {
         List<ActorDTO> responses = ticketService.searchActorsByName(keyword);
         return ApplicationResponse.ok(responses);
+    }
+
+    @Operation(summary = "티켓북 리스트 조회", description = "기간별 티켓북 리스트를 조회합니다.")
+    @GetMapping("/list")
+    public ApplicationResponse<List<TicketRes>> getTicketList(@RequestParam String dateRange) {
+        List<TicketRes> ticketList = ticketService.getTicketList(dateRange);
+        return ApplicationResponse.ok(ticketList);
     }
 
 

--- a/src/main/java/encore/server/domain/ticket/controller/TicketController.java
+++ b/src/main/java/encore/server/domain/ticket/controller/TicketController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,18 +27,10 @@ public class TicketController {
 
 
     @PostMapping
-    public TicketCreateRes createTicket(@RequestBody TicketCreateReq request) {
-        return ticketService.createTicket(request);
+    public ResponseEntity<TicketCreateRes> createTicket(@RequestBody TicketCreateReq request) {
+        TicketCreateRes response = ticketService.createTicket(request);
+        return ResponseEntity.ok(response);
     }
 
 
-
-//    @PostMapping("")
-//    @ResponseStatus(HttpStatus.CREATED)
-//    @Operation(summary = "티켓북 생성 API", description = "티켓북을 생성합니다.")
-//    public ApplicationResponse<TicketReq> createPost(@RequestBody @Valid TicketReq ticketReq, BindingResult bindingResult) {
-//
-//        Long ticketId = ticketService.createTicket(ticketReq);
-//        ApplicationResponse.ok();
-//    }
 }

--- a/src/main/java/encore/server/domain/ticket/controller/TicketController.java
+++ b/src/main/java/encore/server/domain/ticket/controller/TicketController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
@@ -56,6 +57,16 @@ public class TicketController {
     ) {
         TicketRes updatedTicket = ticketService.updateTicket(ticketId, request);
         return ApplicationResponse.ok(updatedTicket);
+    }
+
+    @DeleteMapping("/{ticket_id}")
+    @ResponseStatus(HttpStatus.OK)
+    @Operation(summary = "티켓북 삭제 API", description = "티켓북을 삭제합니다.")
+    public ApplicationResponse deletePost(@PathVariable("ticket_id") Long ticketIdToDelete){
+
+        ticketService.deleteTicket(ticketIdToDelete);
+
+        return ApplicationResponse.ok();
     }
 
 }

--- a/src/main/java/encore/server/domain/ticket/controller/TicketController.java
+++ b/src/main/java/encore/server/domain/ticket/controller/TicketController.java
@@ -2,6 +2,7 @@ package encore.server.domain.ticket.controller;
 
 
 
+import encore.server.domain.ticket.dto.request.ActorDTO;
 import encore.server.domain.ticket.dto.request.TicketCreateReq;
 import encore.server.domain.ticket.dto.response.TicketCreateRes;
 import encore.server.domain.ticket.service.TicketService;
@@ -17,6 +18,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,6 +32,13 @@ public class TicketController {
     public ResponseEntity<TicketCreateRes> createTicket(@RequestBody TicketCreateReq request) {
         TicketCreateRes response = ticketService.createTicket(request);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "배우 검색", description = "배우 이름을 키워드로 검색합니다.")
+    @GetMapping("/actors/search")
+    public ApplicationResponse<List<ActorDTO>> searchActors(@RequestParam String keyword) {
+        List<ActorDTO> responses = ticketService.searchActorsByName(keyword);
+        return ApplicationResponse.ok(responses);
     }
 
 

--- a/src/main/java/encore/server/domain/ticket/converter/TicketConverter.java
+++ b/src/main/java/encore/server/domain/ticket/converter/TicketConverter.java
@@ -11,34 +11,12 @@ import java.util.stream.Collectors;
 
 public class TicketConverter {
 
-    // Ticket -> TicketCreateRes 변환
-    public static TicketCreateRes toCreateResponse(Ticket ticket) {
-        return TicketCreateRes.builder()
-                .id(ticket.getId())
-                .musicalId(ticket.getMusical().getId())
-                .viewedDate(ticket.getViewedDate())
-                .showTime(ticket.getShowTime())
-                .seat(ticket.getSeat())
-                .actors(ticket.getActors().stream()
-                        .map(actor -> new ActorDTO(actor.getId(), actor.getName(), actor.getActorImageUrl()))
-                        .collect(Collectors.toList()))
-                .ticketImageUrl(ticket.getTicketImageUrl())
+    public static ActorDTO toActorDTO(Actor actor) {
+        return ActorDTO.builder()
+                .id(actor.getId())
+                .name(actor.getName())
+                .actorImageUrl(actor.getActorImageUrl())
                 .build();
     }
 
-    // Ticket -> TicketRes 변환
-    public static TicketRes toResponse(Ticket ticket) {
-        return new TicketRes(ticket);
-    }
-
-    // ActorDTO -> Actor 변환
-    public static List<Actor> toActorList(List<ActorDTO> actorDTOs) {
-        return actorDTOs.stream()
-                .map(dto -> Actor.builder()
-                        .id(dto.id())
-                        .name(dto.name())
-                        .actorImageUrl(dto.actorImageUrl())
-                        .build())
-                .collect(Collectors.toList());
-    }
 }

--- a/src/main/java/encore/server/domain/ticket/converter/TicketConverter.java
+++ b/src/main/java/encore/server/domain/ticket/converter/TicketConverter.java
@@ -19,4 +19,22 @@ public class TicketConverter {
                 .build();
     }
 
+    public static TicketCreateRes toTicketCreateRes(Ticket ticket) {
+        return TicketCreateRes.builder()
+                .id(ticket.getId())
+                .userId(ticket.getUser().getId())
+                .musicalId(ticket.getMusical().getId())
+                .viewedDate(ticket.getViewedDate())
+                .showTime(ticket.getShowTime())
+                .seat(ticket.getSeat())
+                .actors(ticket.getActors().stream()
+                        .map(actor -> ActorDTO.builder()
+                                .id(actor.getId())
+                                .name(actor.getName())
+                                .actorImageUrl(actor.getActorImageUrl())
+                                .build())
+                        .collect(Collectors.toList()))
+                .ticketImageUrl(ticket.getTicketImageUrl())
+                .build();
+    }
 }

--- a/src/main/java/encore/server/domain/ticket/converter/TicketConverter.java
+++ b/src/main/java/encore/server/domain/ticket/converter/TicketConverter.java
@@ -1,4 +1,44 @@
 package encore.server.domain.ticket.converter;
 
+import encore.server.domain.ticket.dto.request.ActorDTO;
+import encore.server.domain.ticket.dto.response.TicketCreateRes;
+import encore.server.domain.ticket.dto.response.TicketRes;
+import encore.server.domain.ticket.entity.Actor;
+import encore.server.domain.ticket.entity.Ticket;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
 public class TicketConverter {
+
+    // Ticket -> TicketCreateRes 변환
+    public static TicketCreateRes toCreateResponse(Ticket ticket) {
+        return TicketCreateRes.builder()
+                .id(ticket.getId())
+                .musicalId(ticket.getMusical().getId())
+                .viewedDate(ticket.getViewedDate())
+                .showTime(ticket.getShowTime())
+                .seat(ticket.getSeat())
+                .actors(ticket.getActors().stream()
+                        .map(actor -> new ActorDTO(actor.getId(), actor.getName(), actor.getActorImageUrl()))
+                        .collect(Collectors.toList()))
+                .ticketImageUrl(ticket.getTicketImageUrl())
+                .build();
+    }
+
+    // Ticket -> TicketRes 변환
+    public static TicketRes toResponse(Ticket ticket) {
+        return new TicketRes(ticket);
+    }
+
+    // ActorDTO -> Actor 변환
+    public static List<Actor> toActorList(List<ActorDTO> actorDTOs) {
+        return actorDTOs.stream()
+                .map(dto -> Actor.builder()
+                        .id(dto.id())
+                        .name(dto.name())
+                        .actorImageUrl(dto.actorImageUrl())
+                        .build())
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/encore/server/domain/ticket/dto/request/ActorDTO.java
+++ b/src/main/java/encore/server/domain/ticket/dto/request/ActorDTO.java
@@ -1,0 +1,14 @@
+package encore.server.domain.ticket.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ActorDTO(
+                       Long id,
+                       String name,
+                       String actorImageUrl
+) {
+}

--- a/src/main/java/encore/server/domain/ticket/dto/request/TicketCreateReq.java
+++ b/src/main/java/encore/server/domain/ticket/dto/request/TicketCreateReq.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -13,6 +14,8 @@ public record TicketCreateReq(
         Long userId,
         LocalDate viewedDate,
         String showTime,
-        String seat
+        String seat,
+        List<ActorDTO> actors, // Actor 리스트
+        String ticketImageUrl
 ) {
 }

--- a/src/main/java/encore/server/domain/ticket/dto/request/TicketUpdateReq.java
+++ b/src/main/java/encore/server/domain/ticket/dto/request/TicketUpdateReq.java
@@ -1,0 +1,20 @@
+package encore.server.domain.ticket.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record TicketUpdateReq(
+        String title,
+        LocalDate viewedDate,
+        String showTime,
+        String seat,
+        List<ActorDTO> actors,
+        String ticketImageUrl
+) {
+}

--- a/src/main/java/encore/server/domain/ticket/dto/response/TicketCreateRes.java
+++ b/src/main/java/encore/server/domain/ticket/dto/response/TicketCreateRes.java
@@ -2,29 +2,43 @@ package encore.server.domain.ticket.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import encore.server.domain.ticket.dto.request.ActorDTO;
 import encore.server.domain.ticket.entity.Ticket;
 import lombok.Builder;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record TicketCreateRes(
         Long id,
+        Long userId,
         Long musicalId,
         LocalDate viewedDate,
         String showTime,
         String seat,
-        Long userId
+        List<ActorDTO> actors,
+        String ticketImageUrl
 ) {
     public TicketCreateRes(Ticket ticket) {
         this(
                 ticket.getId(),
+                ticket.getUser().getId(),
                 ticket.getMusical().getId(),
                 ticket.getViewedDate(),
                 ticket.getShowTime(),
                 ticket.getSeat(),
-                ticket.getUser().getId()
+                ticket.getActors().stream()  // Actor -> ActorDTO 변환
+                        .map(actor -> ActorDTO.builder()
+                                .id(actor.getId())
+                                .name(actor.getName())
+                                .actorImageUrl(actor.getActorImageUrl())
+                                .build())
+                        .collect(Collectors.toList()),
+                ticket.getTicketImageUrl()
+
         );
     }
 }

--- a/src/main/java/encore/server/domain/ticket/dto/response/TicketCreateRes.java
+++ b/src/main/java/encore/server/domain/ticket/dto/response/TicketCreateRes.java
@@ -22,23 +22,4 @@ public record TicketCreateRes(
         List<ActorDTO> actors,
         String ticketImageUrl
 ) {
-    public TicketCreateRes(Ticket ticket) {
-        this(
-                ticket.getId(),
-                ticket.getUser().getId(),
-                ticket.getMusical().getId(),
-                ticket.getViewedDate(),
-                ticket.getShowTime(),
-                ticket.getSeat(),
-                ticket.getActors().stream()  // Actor -> ActorDTO 변환
-                        .map(actor -> ActorDTO.builder()
-                                .id(actor.getId())
-                                .name(actor.getName())
-                                .actorImageUrl(actor.getActorImageUrl())
-                                .build())
-                        .collect(Collectors.toList()),
-                ticket.getTicketImageUrl()
-
-        );
-    }
 }

--- a/src/main/java/encore/server/domain/ticket/dto/response/TicketRes.java
+++ b/src/main/java/encore/server/domain/ticket/dto/response/TicketRes.java
@@ -1,4 +1,33 @@
 package encore.server.domain.ticket.dto.response;
 
-public record TicketRes() {
+import encore.server.domain.ticket.entity.Ticket;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Builder
+public record TicketRes(
+        Long id,
+        String musicalTitle,
+        Long series,
+        LocalDate viewedDate,
+        String venue,
+        String seat,
+        List<String> actors
+) {
+    public TicketRes(Ticket ticket) {
+        this(
+                ticket.getId(),
+                ticket.getMusical().getTitle(),
+                ticket.getMusical().getSeries(),
+                ticket.getViewedDate(),
+                ticket.getMusical().getLocation(),
+                ticket.getSeat(),
+                ticket.getActors().stream()
+                        .map(actor -> actor.getName())
+                        .collect(Collectors.toList())
+        );
+    }
 }

--- a/src/main/java/encore/server/domain/ticket/dto/response/TicketRes.java
+++ b/src/main/java/encore/server/domain/ticket/dto/response/TicketRes.java
@@ -1,5 +1,7 @@
 package encore.server.domain.ticket.dto.response;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import encore.server.domain.ticket.entity.Ticket;
 import lombok.Builder;
 
@@ -8,12 +10,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record TicketRes(
         Long id,
         String musicalTitle,
         Long series,
         LocalDate viewedDate,
-        String venue,
+        String location,
         String seat,
         List<String> actors
 ) {

--- a/src/main/java/encore/server/domain/ticket/dto/response/TicketRes.java
+++ b/src/main/java/encore/server/domain/ticket/dto/response/TicketRes.java
@@ -20,6 +20,7 @@ public record TicketRes(
         String seat,
         List<String> actors
 ) {
+    //이 부분도 없애고 builder패턴 사용하도록 변경해야함...
     public TicketRes(Ticket ticket) {
         this(
                 ticket.getId(),

--- a/src/main/java/encore/server/domain/ticket/entity/Actor.java
+++ b/src/main/java/encore/server/domain/ticket/entity/Actor.java
@@ -3,10 +3,11 @@ package encore.server.domain.ticket.entity;
 import encore.server.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-
+@Builder
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -22,4 +23,11 @@ public class Actor extends BaseTimeEntity {
 
     @Column(columnDefinition = "TEXT")
     private String actorImageUrl;
+
+
+    public Actor(Long id, String name, String actorImageUrl) {
+        this.id = id;
+        this.name = name;
+        this.actorImageUrl = actorImageUrl;
+    }
 }

--- a/src/main/java/encore/server/domain/ticket/entity/Ticket.java
+++ b/src/main/java/encore/server/domain/ticket/entity/Ticket.java
@@ -19,7 +19,7 @@ import java.util.List;
 
 @Getter
 @Entity
-@SQLDelete(sql = "UPDATE post SET deleted_at = NOW() where id = ?")
+@SQLDelete(sql = "UPDATE ticket SET deleted_at = NOW() where id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Ticket extends BaseTimeEntity {
     @Id

--- a/src/main/java/encore/server/domain/ticket/entity/Ticket.java
+++ b/src/main/java/encore/server/domain/ticket/entity/Ticket.java
@@ -2,6 +2,7 @@ package encore.server.domain.ticket.entity;
 
 import encore.server.domain.review.entity.Review;
 import encore.server.domain.musical.entity.Musical;
+import encore.server.domain.ticket.dto.request.ActorDTO;
 import encore.server.domain.user.entity.User;
 import encore.server.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
@@ -38,7 +39,7 @@ public class Ticket extends BaseTimeEntity {
     private String title;
 
     @Column(nullable = true, columnDefinition = "text")
-    private String imageUrl;
+    private String ticketImageUrl;
 
     @Column(nullable = false, columnDefinition = "TIMESTAMP")
     private LocalDate viewedDate;
@@ -46,30 +47,31 @@ public class Ticket extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "varchar(255)")
     private String seat;
 
-    //관람 회차 시간, 배우 필드 추가
+    //관람 회차 시간
     @Column(nullable = false, columnDefinition = "varchar(50)")
     private String showTime;
 
-    @ElementCollection(fetch = FetchType.LAZY)
-    @CollectionTable(name = "ticket_actors", joinColumns = @JoinColumn(name = "ticket_id"))
-    @Column(name = "actor_name")
-    private List<String> actors;
-
+    @ManyToMany
+    @JoinTable(
+            name = "ticket_actors",
+            joinColumns = @JoinColumn(name = "ticket_id"),
+            inverseJoinColumns = @JoinColumn(name = "actor_id")
+    )
+    private List<Actor> actors;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_id")
     private Review review;
 
     @Builder
-    public Ticket(User user, Musical musical, String title, String imageUrl, LocalDate viewedDate, String seat, String showTime, List<String> actors) {
+    public Ticket(User user, Musical musical, String title, String ticketImageUrl, LocalDate viewedDate, String seat, String showTime, List<Actor> actors) {
         this.user = user;
         this.musical = musical;
         this.title = title;
-        this.imageUrl = imageUrl;
+        this.ticketImageUrl = ticketImageUrl;
         this.viewedDate = viewedDate;
         this.seat = seat;
         this.showTime = showTime;
         this.actors = actors;
-
     }
 }

--- a/src/main/java/encore/server/domain/ticket/entity/Ticket.java
+++ b/src/main/java/encore/server/domain/ticket/entity/Ticket.java
@@ -74,4 +74,29 @@ public class Ticket extends BaseTimeEntity {
         this.showTime = showTime;
         this.actors = actors;
     }
+
+    // Setter 메서드 추가
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setTicketImageUrl(String ticketImageUrl) {
+        this.ticketImageUrl = ticketImageUrl;
+    }
+
+    public void setViewedDate(LocalDate viewedDate) {
+        this.viewedDate = viewedDate;
+    }
+
+    public void setSeat(String seat) {
+        this.seat = seat;
+    }
+
+    public void setShowTime(String showTime) {
+        this.showTime = showTime;
+    }
+
+    public void setActors(List<Actor> actors) {
+        this.actors = actors;
+    }
 }

--- a/src/main/java/encore/server/domain/ticket/repository/ActorRepository.java
+++ b/src/main/java/encore/server/domain/ticket/repository/ActorRepository.java
@@ -3,5 +3,8 @@ package encore.server.domain.ticket.repository;
 import encore.server.domain.ticket.entity.Actor;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ActorRepository extends JpaRepository<Actor, Long> {
+    List<Actor> findByNameContaining(String keyword);
 }

--- a/src/main/java/encore/server/domain/ticket/repository/ActorRepository.java
+++ b/src/main/java/encore/server/domain/ticket/repository/ActorRepository.java
@@ -1,0 +1,7 @@
+package encore.server.domain.ticket.repository;
+
+import encore.server.domain.ticket.entity.Actor;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActorRepository extends JpaRepository<Actor, Long> {
+}

--- a/src/main/java/encore/server/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/encore/server/domain/ticket/repository/TicketRepository.java
@@ -3,5 +3,9 @@ package encore.server.domain.ticket.repository;
 import encore.server.domain.ticket.entity.Ticket;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
+    List<Ticket> findByViewedDateAfter(LocalDate date);
 }

--- a/src/main/java/encore/server/domain/ticket/repository/TicketRepository.java
+++ b/src/main/java/encore/server/domain/ticket/repository/TicketRepository.java
@@ -1,11 +1,20 @@
 package encore.server.domain.ticket.repository;
 
 import encore.server.domain.ticket.entity.Ticket;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
-    List<Ticket> findByViewedDateAfter(LocalDate date);
+    List<Ticket> findByViewedDateAfterAndDeletedAtIsNull(LocalDate date);
+
+    List<Ticket> findByDeletedAtIsNull();
+
+    @Modifying
+    @Query("UPDATE Ticket t SET t.deletedAt = CURRENT_TIMESTAMP WHERE t.id = :ticketId")
+    void softDeleteByTicketId(@Param("ticketId") Long ticketId);
 }

--- a/src/main/java/encore/server/domain/ticket/service/TicketService.java
+++ b/src/main/java/encore/server/domain/ticket/service/TicketService.java
@@ -66,8 +66,8 @@ public class TicketService {
 
         ticketRepository.save(ticket);
 
-
-        return new TicketCreateRes(ticket);
+        // TicketConverter 이용
+        return TicketConverter.toTicketCreateRes(ticket);
 
     }
 
@@ -75,7 +75,7 @@ public class TicketService {
     public List<ActorDTO> searchActorsByName(String keyword) {
         List<Actor> actors = actorRepository.findByNameContaining(keyword);
         return actors.stream()
-                .map(TicketConverter::toActorDTO) // Converter를 활용한 변환
+                .map(TicketConverter::toActorDTO) // Converter를 이용해 변환
                 .toList();
     }
 

--- a/src/main/java/encore/server/domain/ticket/service/TicketService.java
+++ b/src/main/java/encore/server/domain/ticket/service/TicketService.java
@@ -15,6 +15,7 @@ import encore.server.domain.ticket.repository.ActorRepository;
 import encore.server.domain.ticket.repository.TicketRepository;
 import encore.server.domain.user.entity.User;
 import encore.server.domain.user.repository.UserRepository;
+import encore.server.global.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -92,9 +93,9 @@ public class TicketService {
         List<Ticket> tickets;
 
         if (startDate != null) {
-            tickets = ticketRepository.findByViewedDateAfter(startDate);
+            tickets = ticketRepository.findByViewedDateAfterAndDeletedAtIsNull(startDate);
         } else {
-            tickets = ticketRepository.findAll();
+            tickets = ticketRepository.findByDeletedAtIsNull();
         }
 
         return tickets.stream()
@@ -139,4 +140,13 @@ public class TicketService {
         return new TicketRes(ticket);
     }
 
+    //티켓북 삭제
+    @Transactional
+    public void deleteTicket(Long ticketId) {
+
+        if(!ticketRepository.existsById(ticketId)){
+            throw new BadRequestException("Ticket does not exist");
+        }
+        ticketRepository.softDeleteByTicketId(ticketId);
+    }
 }

--- a/src/main/java/encore/server/domain/ticket/service/TicketService.java
+++ b/src/main/java/encore/server/domain/ticket/service/TicketService.java
@@ -68,4 +68,11 @@ public class TicketService {
 
     }
 
+    public List<ActorDTO> searchActorsByName(String keyword) {
+        List<Actor> actors = actorRepository.findByNameContaining(keyword);
+        return actors.stream()
+                .map(actor -> new ActorDTO(actor.getId(), actor.getName(), actor.getActorImageUrl()))
+                .collect(Collectors.toList());
+    }
+
 }

--- a/src/main/java/encore/server/domain/ticket/service/TicketService.java
+++ b/src/main/java/encore/server/domain/ticket/service/TicketService.java
@@ -6,6 +6,7 @@ import encore.server.domain.musical.repository.MusicalRepository;
 import encore.server.domain.ticket.converter.TicketConverter;
 import encore.server.domain.ticket.dto.request.ActorDTO;
 import encore.server.domain.ticket.dto.request.TicketCreateReq;
+import encore.server.domain.ticket.dto.request.TicketUpdateReq;
 import encore.server.domain.ticket.dto.response.TicketCreateRes;
 import encore.server.domain.ticket.dto.response.TicketRes;
 import encore.server.domain.ticket.entity.Actor;
@@ -99,6 +100,43 @@ public class TicketService {
         return tickets.stream()
                 .map(TicketRes::new)
                 .collect(Collectors.toList());
+    }
+
+    //티켓북 수정
+    @Transactional
+    public TicketRes updateTicket(Long ticketId, TicketUpdateReq request) {
+        //Validation
+        Ticket ticket = ticketRepository.findById(ticketId)
+                .orElseThrow(() -> new RuntimeException("Ticket not found"));
+
+        if (request.title() != null) {
+            ticket.setTitle(request.title());
+        }
+        if (request.viewedDate() != null) {
+            ticket.setViewedDate(request.viewedDate());
+        }
+        if (request.showTime() != null) {
+            ticket.setShowTime(request.showTime());
+        }
+        if (request.seat() != null) {
+            ticket.setSeat(request.seat());
+        }
+        if (request.actors() != null) {
+            List<Actor> actors = request.actors().stream()
+                    .map(actorDTO -> Actor.builder()
+                            .id(actorDTO.id())
+                            .name(actorDTO.name())
+                            .actorImageUrl(actorDTO.actorImageUrl())
+                            .build())
+                    .collect(Collectors.toList());
+            ticket.setActors(actors);
+        }
+        if (request.ticketImageUrl() != null) {
+            ticket.setTicketImageUrl(request.ticketImageUrl());
+        }
+
+        ticketRepository.save(ticket);
+        return new TicketRes(ticket);
     }
 
 }

--- a/src/main/java/encore/server/domain/ticket/service/TicketService.java
+++ b/src/main/java/encore/server/domain/ticket/service/TicketService.java
@@ -3,6 +3,7 @@ package encore.server.domain.ticket.service;
 import encore.server.domain.image.service.ImageService;
 import encore.server.domain.musical.entity.Musical;
 import encore.server.domain.musical.repository.MusicalRepository;
+import encore.server.domain.ticket.converter.TicketConverter;
 import encore.server.domain.ticket.dto.request.ActorDTO;
 import encore.server.domain.ticket.dto.request.TicketCreateReq;
 import encore.server.domain.ticket.dto.response.TicketCreateRes;
@@ -17,6 +18,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -33,24 +35,17 @@ public class TicketService {
 
     @Transactional
     public TicketCreateRes createTicket(TicketCreateReq request) {
-
-        //validation
+        // Validation
         Musical musical = musicalRepository.findById(request.musicalId())
                 .orElseThrow(() -> new RuntimeException("Musical not found"));
 
         User user = userRepository.findById(request.userId())
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
-        //actordto->actor
-        List<Actor> actors = request.actors().stream()
-                .map(actorDTO -> Actor.builder()
-                        .id(actorDTO.id())
-                        .name(actorDTO.name())
-                        .actorImageUrl(actorDTO.actorImageUrl())
-                        .build())
-                .collect(Collectors.toList());
+        // DTO -> Entity 변환
+        List<Actor> actors = TicketConverter.toActorList(request.actors());
 
-        //create ticket
+        // Ticket 생성
         Ticket ticket = Ticket.builder()
                 .user(user)
                 .musical(musical)
@@ -61,18 +56,36 @@ public class TicketService {
                 .ticketImageUrl(request.ticketImageUrl())
                 .build();
 
+        // 저장
         ticketRepository.save(ticket);
 
-
-        return new TicketCreateRes(ticket);
-
+        // Entity -> DTO 변환
+        return TicketConverter.toCreateResponse(ticket);
     }
 
     public List<ActorDTO> searchActorsByName(String keyword) {
         List<Actor> actors = actorRepository.findByNameContaining(keyword);
         return actors.stream()
                 .map(actor -> new ActorDTO(actor.getId(), actor.getName(), actor.getActorImageUrl()))
-                .collect(Collectors.toList());
+                .toList();
+    }
+
+    public List<TicketRes> getTicketList(String dateRange) {
+        LocalDate startDate = switch (dateRange) {
+            case "WEEK" -> LocalDate.now().minusWeeks(1);
+            case "MONTH" -> LocalDate.now().minusMonths(1);
+            case "YEAR" -> LocalDate.now().minusYears(1);
+            default -> null; // ALL: 전체 조회
+        };
+
+        List<Ticket> tickets = (startDate != null) ?
+                ticketRepository.findByViewedDateAfter(startDate) :
+                ticketRepository.findAll();
+
+        // Entity -> DTO 변환
+        return tickets.stream()
+                .map(TicketConverter::toResponse)
+                .toList();
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #40 #55 #56

## 📝작업 내용
> 초기 티켓북 생성 api를 티켓 실물 이미지, 배우 정보들까지 받아서 생성하는것으로 변경
> (converter사용하는 것으로는 내일 수정하겠습니다!)
### 스크린샷 (선택)
요청 
![image](https://github.com/user-attachments/assets/24c83e0d-59ed-4fdb-8e3c-1fe400de8c3d)
응답
![image](https://github.com/user-attachments/assets/dc28386f-509e-4653-a506-3c85f3529a23)
> 배우 검색 api도 추가하였습니다.

## 💬리뷰 요구사항(선택)
> 이렇게 한번에 프론트에서 정보를 받아서 생성해도 될까요?
>
>
