### PR TITLE
뮤지컬 상세조회 API 구현

### DIFF
--- a/src/main/java/encore/server/domain/musical/controller/MusicalController.java
+++ b/src/main/java/encore/server/domain/musical/controller/MusicalController.java
@@ -1,5 +1,6 @@
 package encore.server.domain.musical.controller;
 
+import encore.server.domain.musical.dto.response.MusicalDetailRes;
 import encore.server.domain.musical.dto.response.MusicalRes;
 import encore.server.domain.musical.entity.Musical;
 import encore.server.domain.musical.service.MusicalService;
@@ -8,10 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -28,6 +26,12 @@ public class MusicalController {
     public ApplicationResponse<List<MusicalRes>> searchMusicals(@RequestParam String keyword) {
         List<MusicalRes> responses = musicalService.searchMusicalsByTitle(keyword);
         return ApplicationResponse.ok(responses);
+    }
+
+    @Operation(summary = "뮤지컬 상세조회", description = "뮤지컬을 상세조회합니다.")
+    @GetMapping("/{id}")
+    public MusicalDetailRes getMusicalDetail(@PathVariable Long id) {
+        return musicalService.getMusicalDetail(id);
     }
 
 }

--- a/src/main/java/encore/server/domain/musical/controller/MusicalController.java
+++ b/src/main/java/encore/server/domain/musical/controller/MusicalController.java
@@ -2,6 +2,7 @@ package encore.server.domain.musical.controller;
 
 import encore.server.domain.musical.dto.response.MusicalDetailRes;
 import encore.server.domain.musical.dto.response.MusicalRes;
+import encore.server.domain.musical.dto.response.MusicalSeriesRes;
 import encore.server.domain.musical.entity.Musical;
 import encore.server.domain.musical.service.MusicalService;
 import encore.server.domain.review.dto.response.ReviewDetailRes;
@@ -34,6 +35,15 @@ public class MusicalController {
     public ApplicationResponse<MusicalDetailRes> getMusicalDetail(@PathVariable("musical_id") Long musicalId) {
         return ApplicationResponse.ok(musicalService.getMusicalDetail(musicalId));
     }
+
+    @Operation(summary = "같은 제목의 모든 Series 조회", description = "뮤지컬 ID로 같은 제목의 모든 Series를 조회합니다.")
+    @GetMapping("/{musical_id}/all-series")
+    public ApplicationResponse<List<MusicalSeriesRes>> getAllSeries(@PathVariable("musical_id") Long musicalId) {
+        List<MusicalSeriesRes> responses = musicalService.getAllSeriesByMusicalId(musicalId);
+        return ApplicationResponse.ok(responses);
+    }
+
+
 
 }
 

--- a/src/main/java/encore/server/domain/musical/controller/MusicalController.java
+++ b/src/main/java/encore/server/domain/musical/controller/MusicalController.java
@@ -4,6 +4,7 @@ import encore.server.domain.musical.dto.response.MusicalDetailRes;
 import encore.server.domain.musical.dto.response.MusicalRes;
 import encore.server.domain.musical.entity.Musical;
 import encore.server.domain.musical.service.MusicalService;
+import encore.server.domain.review.dto.response.ReviewDetailRes;
 import encore.server.global.common.ApplicationResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,9 +30,9 @@ public class MusicalController {
     }
 
     @Operation(summary = "뮤지컬 상세조회", description = "뮤지컬을 상세조회합니다.")
-    @GetMapping("/{id}")
-    public MusicalDetailRes getMusicalDetail(@PathVariable Long id) {
-        return musicalService.getMusicalDetail(id);
+    @GetMapping("/{musical_id}")
+    public ApplicationResponse<MusicalDetailRes> getMusicalDetail(@PathVariable("musical_id") Long musicalId) {
+        return ApplicationResponse.ok(musicalService.getMusicalDetail(musicalId));
     }
 
 }

--- a/src/main/java/encore/server/domain/musical/converter/MusicalConverter.java
+++ b/src/main/java/encore/server/domain/musical/converter/MusicalConverter.java
@@ -1,7 +1,12 @@
 package encore.server.domain.musical.converter;
 
+import encore.server.domain.musical.dto.response.MusicalDetailRes;
 import encore.server.domain.musical.dto.response.MusicalRes;
 import encore.server.domain.musical.entity.Musical;
+import encore.server.domain.musical.entity.MusicalActor;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class MusicalConverter {
     public static MusicalRes toResponse(Musical musical) {
@@ -12,5 +17,31 @@ public class MusicalConverter {
                 .location(musical.getLocation())
                 .showTimes(musical.getShowTimes())
                 .build();
+    }
+
+    public static MusicalDetailRes toMusicalDetailRes(Musical musical) {
+        return MusicalDetailRes.builder()
+                .id(musical.getId())
+                .title(musical.getTitle())
+                .startDate(musical.getStartDate())
+                .endDate(musical.getEndDate())
+                .location(musical.getLocation())
+                .runningTime(musical.getRunningTime())
+                .age(musical.getAge())
+                .series(musical.getSeries())
+                .imageUrl(musical.getImageUrl())
+                .actors(toActorResponses(musical.getMusicalActors()))
+                .build();
+    }
+
+    private static List<MusicalDetailRes.MusicalActorRes> toActorResponses(List<MusicalActor> musicalActors) {
+        return musicalActors.stream()
+                .map(actor -> MusicalDetailRes.MusicalActorRes.builder()
+                        .actorName(actor.getActor().getName())
+                        .actorImageUrl(actor.getActor().getActorImageUrl())
+                        .roleName(actor.getRoleName())
+                        .isMainActor(actor.isMainActor())
+                        .build())
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/encore/server/domain/musical/dto/response/MusicalDetailRes.java
+++ b/src/main/java/encore/server/domain/musical/dto/response/MusicalDetailRes.java
@@ -1,0 +1,31 @@
+package encore.server.domain.musical.dto.response;
+
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record MusicalDetailRes(
+        Long id,
+        String title,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        String location,
+        Long runningTime,
+        Long age,
+        Long series,
+        String imageUrl,
+        List<MusicalActorRes> actors
+) {
+    @Builder
+    public record MusicalActorRes(
+            String actorName,
+            String actorImageUrl,
+            String roleName,
+            boolean isMainActor
+    ) {
+    }
+}
+

--- a/src/main/java/encore/server/domain/musical/dto/response/MusicalDetailRes.java
+++ b/src/main/java/encore/server/domain/musical/dto/response/MusicalDetailRes.java
@@ -1,12 +1,15 @@
 package encore.server.domain.musical.dto.response;
 
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record MusicalDetailRes(
         Long id,
         String title,

--- a/src/main/java/encore/server/domain/musical/dto/response/MusicalSeriesRes.java
+++ b/src/main/java/encore/server/domain/musical/dto/response/MusicalSeriesRes.java
@@ -1,0 +1,15 @@
+package encore.server.domain.musical.dto.response;
+
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record MusicalSeriesRes(
+        Long id,
+        Long series,
+        boolean isCurrent
+) {
+}

--- a/src/main/java/encore/server/domain/musical/entity/Musical.java
+++ b/src/main/java/encore/server/domain/musical/entity/Musical.java
@@ -52,4 +52,7 @@ public class Musical extends BaseTimeEntity {
     @Column(name = "show_time")
     private List<String> showTimes = new ArrayList<>();
 
+    @OneToMany(mappedBy = "musical", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MusicalActor> musicalActors = new ArrayList<>();
+
 }

--- a/src/main/java/encore/server/domain/musical/entity/MusicalActor.java
+++ b/src/main/java/encore/server/domain/musical/entity/MusicalActor.java
@@ -1,0 +1,43 @@
+package encore.server.domain.musical.entity;
+
+import encore.server.domain.ticket.entity.Actor;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Getter
+@Entity
+@Table(name = "musical_actor")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MusicalActor {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, columnDefinition = "bigint")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "musical_id", nullable = false)
+    private Musical musical;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "actor_id", nullable = false)
+    private Actor actor;
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    private String roleName; // 배역 이름
+
+    @Column(nullable = false)
+    private boolean isMainActor; // 주연 여부
+
+    @Builder
+    public MusicalActor(Musical musical, Actor actor, String roleName, boolean isMainActor) {
+        this.musical = musical;
+        this.actor = actor;
+        this.roleName = roleName;
+        this.isMainActor = isMainActor;
+    }
+}

--- a/src/main/java/encore/server/domain/musical/repository/MusicalRepository.java
+++ b/src/main/java/encore/server/domain/musical/repository/MusicalRepository.java
@@ -2,6 +2,7 @@ package encore.server.domain.musical.repository;
 
 import encore.server.domain.musical.entity.Musical;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -9,4 +10,8 @@ import java.util.Optional;
 public interface MusicalRepository extends JpaRepository<Musical, Long> {
     List<Musical> findByTitleContaining(String keyword);
     Optional<Musical> findByIdAndDeletedAtIsNull(Long id);
+
+    @Query("SELECT m FROM Musical m WHERE m.title = :title AND m.deletedAt IS NULL")
+    List<Musical> findByTitle(String title);
+
 }

--- a/src/main/java/encore/server/domain/musical/repository/MusicalRepository.java
+++ b/src/main/java/encore/server/domain/musical/repository/MusicalRepository.java
@@ -4,7 +4,9 @@ import encore.server.domain.musical.entity.Musical;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface MusicalRepository extends JpaRepository<Musical, Long> {
     List<Musical> findByTitleContaining(String keyword);
+    Optional<Musical> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/encore/server/domain/musical/repository/MusicalRepository.java
+++ b/src/main/java/encore/server/domain/musical/repository/MusicalRepository.java
@@ -10,8 +10,6 @@ import java.util.Optional;
 public interface MusicalRepository extends JpaRepository<Musical, Long> {
     List<Musical> findByTitleContaining(String keyword);
     Optional<Musical> findByIdAndDeletedAtIsNull(Long id);
-
-    @Query("SELECT m FROM Musical m WHERE m.title = :title AND m.deletedAt IS NULL")
-    List<Musical> findByTitle(String title);
+    List<Musical> findByTitleAndDeletedAtIsNull(String title);
 
 }

--- a/src/main/java/encore/server/domain/musical/service/MusicalService.java
+++ b/src/main/java/encore/server/domain/musical/service/MusicalService.java
@@ -40,7 +40,7 @@ public class MusicalService {
         Musical currentMusical = musicalRepository.findByIdAndDeletedAtIsNull(musicalId)
                 .orElseThrow(() -> new ApplicationException(ErrorCode.MUSICAL_NOT_FOUND_EXCEPTION));
 
-        List<Musical> musicals = musicalRepository.findByTitle(currentMusical.getTitle());
+        List<Musical> musicals = musicalRepository.findByTitleAndDeletedAtIsNull(currentMusical.getTitle());
 
         return musicals.stream()
                 .map(musical -> MusicalSeriesRes.builder()

--- a/src/main/java/encore/server/domain/musical/service/MusicalService.java
+++ b/src/main/java/encore/server/domain/musical/service/MusicalService.java
@@ -3,6 +3,7 @@ package encore.server.domain.musical.service;
 import encore.server.domain.musical.converter.MusicalConverter;
 import encore.server.domain.musical.dto.response.MusicalDetailRes;
 import encore.server.domain.musical.dto.response.MusicalRes;
+import encore.server.domain.musical.dto.response.MusicalSeriesRes;
 import encore.server.domain.musical.entity.Musical;
 import encore.server.domain.musical.repository.MusicalRepository;
 import encore.server.domain.review.entity.Review;
@@ -34,4 +35,20 @@ public class MusicalService {
 
         return MusicalConverter.toMusicalDetailRes(musical);
     }
+
+    public List<MusicalSeriesRes> getAllSeriesByMusicalId(Long musicalId) {
+        Musical currentMusical = musicalRepository.findByIdAndDeletedAtIsNull(musicalId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.MUSICAL_NOT_FOUND_EXCEPTION));
+
+        List<Musical> musicals = musicalRepository.findByTitle(currentMusical.getTitle());
+
+        return musicals.stream()
+                .map(musical -> MusicalSeriesRes.builder()
+                        .id(musical.getId())
+                        .series(musical.getSeries())
+                        .isCurrent(musical.getId().equals(musicalId)) // 현재 선택된 시리즈 표시
+                        .build())
+                .toList();
+    }
+
 }

--- a/src/main/java/encore/server/domain/musical/service/MusicalService.java
+++ b/src/main/java/encore/server/domain/musical/service/MusicalService.java
@@ -1,9 +1,13 @@
 package encore.server.domain.musical.service;
 
 import encore.server.domain.musical.converter.MusicalConverter;
+import encore.server.domain.musical.dto.response.MusicalDetailRes;
 import encore.server.domain.musical.dto.response.MusicalRes;
 import encore.server.domain.musical.entity.Musical;
 import encore.server.domain.musical.repository.MusicalRepository;
+import encore.server.domain.review.entity.Review;
+import encore.server.global.exception.ApplicationException;
+import encore.server.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,5 +25,13 @@ public class MusicalService {
         return musicals.stream()
                 .map(MusicalConverter::toResponse) // Converter를 이용해 변환으로 수정!
                 .toList();
+    }
+
+    public MusicalDetailRes getMusicalDetail(Long musicalId) {
+        //validation
+        Musical musical = musicalRepository.findByIdAndDeletedAtIsNull(musicalId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.MUSICAL_NOT_FOUND_EXCEPTION));
+
+        return MusicalConverter.toMusicalDetailRes(musical);
     }
 }

--- a/src/main/java/encore/server/domain/review/controller/ReviewController.java
+++ b/src/main/java/encore/server/domain/review/controller/ReviewController.java
@@ -12,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -111,9 +110,9 @@ public class ReviewController {
 
     @GetMapping("/musical/{musical_id}/reviews")
     @Operation(summary = "뮤지컬의 전체리뷰조회", description = "해당 뮤지컬의 프리미엄리뷰 전체정보를 조회합니다.")
-    public ResponseEntity<ReviewSummaryRes> getReviews(@PathVariable("musical_id") Long musicalId) {
+    public ApplicationResponse<ReviewSummaryRes> getReviews(@PathVariable("musical_id") Long musicalId) {
         ReviewSummaryRes response = reviewService.getReviewsByMusical(musicalId);
-        return ResponseEntity.ok(response);
+        return ApplicationResponse.ok(response);
     }
 
     private Long getUserId() {

--- a/src/main/java/encore/server/domain/review/controller/ReviewController.java
+++ b/src/main/java/encore/server/domain/review/controller/ReviewController.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -106,6 +107,13 @@ public class ReviewController {
         Long userId = getUserId();
         reviewSearchService.deleteAllRecentSearchLogs(userId);
         return ApplicationResponse.ok();
+    }
+
+    @GetMapping("/musical/{musical_id}/reviews")
+    @Operation(summary = "뮤지컬의 전체리뷰조회", description = "해당 뮤지컬의 프리미엄리뷰 전체정보를 조회합니다.")
+    public ResponseEntity<ReviewSummaryRes> getReviews(@PathVariable("musical_id") Long musicalId) {
+        ReviewSummaryRes response = reviewService.getReviewsByMusical(musicalId);
+        return ResponseEntity.ok(response);
     }
 
     private Long getUserId() {

--- a/src/main/java/encore/server/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/encore/server/domain/review/converter/ReviewConverter.java
@@ -169,20 +169,18 @@ public class ReviewConverter {
                 .build();
     }
 
-    public static ReviewRes toReviewRes(Review review) {
+    public static ReviewRes toReviewRes(Review review, String elapsedTime) {
         return ReviewRes.builder()
                 .title(review.getTitle())
                 .nickName(review.getUser().getNickName())
+                .elapsedTime(elapsedTime)
                 .totalRating(review.getReviewData().getRating().getTotalRating())
                 .viewCount(review.getViewCount())
                 .likeCount(review.getLikeCount())
                 .build();
     }
 
-    public static ReviewSummaryRes toReviewSummaryRes(List<Review> reviews) {
-        List<ReviewRes> reviewResList = reviews.stream()
-                .map(ReviewConverter::toReviewRes)
-                .toList();
+    public static ReviewSummaryRes toReviewSummaryRes(List<ReviewRes> reviewResList, List<Review> reviews) {
 
         double averageTotalRating = reviews.stream()
                 .mapToDouble(r -> r.getReviewData().getRating().getTotalRating())

--- a/src/main/java/encore/server/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/encore/server/domain/review/converter/ReviewConverter.java
@@ -168,4 +168,54 @@ public class ReviewConverter {
                         .build())
                 .build();
     }
+
+    public static ReviewRes toReviewRes(Review review) {
+        return ReviewRes.builder()
+                .title(review.getTitle())
+                .nickName(review.getUser().getNickName())
+                .totalRating(review.getReviewData().getRating().getTotalRating())
+                .viewCount(review.getViewCount())
+                .likeCount(review.getLikeCount())
+                .build();
+    }
+
+    public static ReviewSummaryRes toReviewSummaryRes(List<Review> reviews) {
+        List<ReviewRes> reviewResList = reviews.stream()
+                .map(ReviewConverter::toReviewRes)
+                .toList();
+
+        double averageTotalRating = reviews.stream()
+                .mapToDouble(r -> r.getReviewData().getRating().getTotalRating())
+                .average().orElse(0.0);
+
+        double averageNumberRating = reviews.stream()
+                .mapToDouble(r -> r.getReviewData().getRating().getNumberRating())
+                .average().orElse(0.0);
+
+        double averageStoryRating = reviews.stream()
+                .mapToDouble(r -> r.getReviewData().getRating().getStoryRating())
+                .average().orElse(0.0);
+
+        double averageRevisitRating = reviews.stream()
+                .mapToDouble(r -> r.getReviewData().getRating().getRevisitRating())
+                .average().orElse(0.0);
+
+        double averageActorRating = reviews.stream()
+                .mapToDouble(r -> r.getReviewData().getRating().getActorRating())
+                .average().orElse(0.0);
+
+        double averagePerformanceRating = reviews.stream()
+                .mapToDouble(r -> r.getReviewData().getRating().getPerformanceRating())
+                .average().orElse(0.0);
+
+        return ReviewSummaryRes.builder()
+                .reviews(reviewResList)
+                .averageTotalRating((float) averageTotalRating)
+                .averageNumberRating((float) averageNumberRating)
+                .averageStoryRating((float) averageStoryRating)
+                .averageRevisitRating((float) averageRevisitRating)
+                .averageActorRating((float) averageActorRating)
+                .averagePerformanceRating((float) averagePerformanceRating)
+                .build();
+    }
 }

--- a/src/main/java/encore/server/domain/review/dto/response/ReviewRes.java
+++ b/src/main/java/encore/server/domain/review/dto/response/ReviewRes.java
@@ -3,15 +3,27 @@ package encore.server.domain.review.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record ReviewRes(
+        @Schema(description = "리뷰 제목", example = "위키드 리뷰")
         String title,
+
+        @Schema(description = "유저 닉네임", example = "뮤사랑")
         String nickName,
+
+        @Schema(description = "총점", example = "4.5")
         Float totalRating,
+
+        @Schema(description = "조회수", example = "100")
         Long viewCount,
+
+        @Schema(description = "좋아요수", example = "50")
         Long likeCount
+
+
 ) {
 }

--- a/src/main/java/encore/server/domain/review/dto/response/ReviewRes.java
+++ b/src/main/java/encore/server/domain/review/dto/response/ReviewRes.java
@@ -1,0 +1,17 @@
+package encore.server.domain.review.dto.response;
+
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ReviewRes(
+        String title,
+        String nickName,
+        Float totalRating,
+        Long viewCount,
+        Long likeCount
+) {
+}

--- a/src/main/java/encore/server/domain/review/dto/response/ReviewRes.java
+++ b/src/main/java/encore/server/domain/review/dto/response/ReviewRes.java
@@ -15,6 +15,9 @@ public record ReviewRes(
         @Schema(description = "유저 닉네임", example = "뮤사랑")
         String nickName,
 
+        @Schema(description = "업로드 시점", example = "11분 전")
+        String elapsedTime,
+
         @Schema(description = "총점", example = "4.5")
         Float totalRating,
 

--- a/src/main/java/encore/server/domain/review/dto/response/ReviewSummaryRes.java
+++ b/src/main/java/encore/server/domain/review/dto/response/ReviewSummaryRes.java
@@ -1,0 +1,20 @@
+package encore.server.domain.review.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ReviewSummaryRes(
+        List<ReviewRes> reviews,
+        Float averageTotalRating,
+        Float averageNumberRating,
+        Float averageStoryRating,
+        Float averageRevisitRating,
+        Float averageActorRating,
+        Float averagePerformanceRating
+) {
+}

--- a/src/main/java/encore/server/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/encore/server/domain/review/repository/ReviewRepository.java
@@ -1,7 +1,9 @@
 package encore.server.domain.review.repository;
 
 import encore.server.domain.review.entity.Review;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +12,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
     Optional<Review> findByTicketIdAndDeletedAtIsNull(Long ticketId);
     Optional<Review> findByIdAndDeletedAtIsNull(Long reviewId);
     List<Review> findByUserIdAndDeletedAtIsNull(Long userId);
+
+    @Query("SELECT r FROM Review r " +
+            "JOIN FETCH r.user u " +
+            "JOIN FETCH r.ticket t " +
+            "WHERE t.musical.id = :musicalId AND r.deletedAt IS NULL")
+    List<Review> findReviewsByMusicalId(@Param("musicalId") Long musicalId);
 }

--- a/src/main/java/encore/server/domain/review/service/ReviewService.java
+++ b/src/main/java/encore/server/domain/review/service/ReviewService.java
@@ -251,6 +251,18 @@ public class ReviewService {
 
     public ReviewSummaryRes getReviewsByMusical(Long musicalId) {
         List<Review> reviews = reviewRepository.findReviewsByMusicalId(musicalId);
-        return ReviewConverter.toReviewSummaryRes(reviews);
+
+        //각 리뷰의 elapsedTime을 계산해서 ReviewRes 리스트로 변환
+        List<ReviewRes> reviewResList = reviews.stream()
+                .map(review -> {
+                    long minutesAgo = ChronoUnit.MINUTES.between(review.getCreatedAt(), LocalDateTime.now());
+                    String elapsedTime = getElapsedTime(minutesAgo);
+                    return ReviewConverter.toReviewRes(review, elapsedTime);  // elapsedTime을 전달
+                })
+                .toList();
+
+        //reviewResList를 전달하여 SummaryRes 생성
+        return ReviewConverter.toReviewSummaryRes(reviewResList, reviews);
+
     }
 }

--- a/src/main/java/encore/server/domain/review/service/ReviewService.java
+++ b/src/main/java/encore/server/domain/review/service/ReviewService.java
@@ -248,4 +248,9 @@ public class ReviewService {
         Boolean isLike = reviewLikeRepository.existsByReviewAndUserAndIsLikeTrue(review, review.getUser());
         return ReviewConverter.toReviewSimpleRes(review, elapsedTime, isLike);
     }
+
+    public ReviewSummaryRes getReviewsByMusical(Long musicalId) {
+        List<Review> reviews = reviewRepository.findReviewsByMusicalId(musicalId);
+        return ReviewConverter.toReviewSummaryRes(reviews);
+    }
 }

--- a/src/main/java/encore/server/domain/ticket/entity/Actor.java
+++ b/src/main/java/encore/server/domain/ticket/entity/Actor.java
@@ -1,11 +1,15 @@
 package encore.server.domain.ticket.entity;
 
+import encore.server.domain.musical.entity.MusicalActor;
 import encore.server.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Builder
 @Getter
@@ -24,10 +28,14 @@ public class Actor extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT")
     private String actorImageUrl;
 
+    @OneToMany(mappedBy = "actor", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MusicalActor> musicalActors = new ArrayList<>();
 
-    public Actor(Long id, String name, String actorImageUrl) {
+
+    public Actor(Long id, String name, String actorImageUrl, List<MusicalActor> musicalActors) {
         this.id = id;
         this.name = name;
         this.actorImageUrl = actorImageUrl;
+        this.musicalActors = musicalActors != null ? musicalActors : new ArrayList<>();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
> #60 

## 📝작업 내용
> 뮤지컬 내용 상세 조회 API
> 해당 뮤지컬의 모든 프리미엄 리뷰 조회 API 

> 같은 제목인 모든 시리즈 조회하는 API 


## 💬리뷰 요구사항(선택)
> 해당 뮤지컬의 모든 프리미엄 리뷰 조회 API를 /review/musical/{musical_id}/reviews
이렇게 review와 관련되어 있어서 reviewController에 작성했는데 
musical에 작성하는게 맞을까요? 이상한거 같기도 하여 의견 부탁드립니다.

> 드롭다운으로 같은 제목의 다른 시리즈 내용을 불러오는 기능이 있던데, 뮤지컬 id를 받아서 같은 제목의 뮤지컬 id, series, is_current(현재 선택되어 있는 뮤지컬인지 아닌지) 를 반환하도록 설계하였습니다. 
