### PR TITLE
이달의 인기 뮤지컬/ 개봉 예정 뮤지컬 조회 API

### DIFF
--- a/src/main/java/encore/server/domain/musical/controller/MusicalController.java
+++ b/src/main/java/encore/server/domain/musical/controller/MusicalController.java
@@ -3,6 +3,7 @@ package encore.server.domain.musical.controller;
 import encore.server.domain.musical.dto.response.MusicalDetailRes;
 import encore.server.domain.musical.dto.response.MusicalRes;
 import encore.server.domain.musical.dto.response.MusicalSeriesRes;
+import encore.server.domain.musical.dto.response.MusicalSimpleRes;
 import encore.server.domain.musical.entity.Musical;
 import encore.server.domain.musical.service.MusicalService;
 import encore.server.domain.review.dto.response.ReviewDetailRes;
@@ -41,6 +42,13 @@ public class MusicalController {
     public ApplicationResponse<List<MusicalSeriesRes>> getAllSeries(@PathVariable("musical_id") Long musicalId) {
         List<MusicalSeriesRes> responses = musicalService.getAllSeriesByMusicalId(musicalId);
         return ApplicationResponse.ok(responses);
+    }
+
+    @Operation(summary = "이달의 인기 뮤지컬 조회", description = "이달의 인기 뮤지컬 8개를 조회합니다.")
+    @GetMapping("/featured")
+    public ApplicationResponse<List<MusicalSimpleRes>> getFeaturedMusicals() {
+        List<MusicalSimpleRes> musicals = musicalService.getFeaturedMusicals();
+        return ApplicationResponse.ok(musicals);
     }
 
 

--- a/src/main/java/encore/server/domain/musical/controller/MusicalController.java
+++ b/src/main/java/encore/server/domain/musical/controller/MusicalController.java
@@ -51,6 +51,12 @@ public class MusicalController {
         return ApplicationResponse.ok(musicals);
     }
 
+    @Operation(summary = "개봉 예정 뮤지컬 조회", description = "개봉이 임박한 뮤지컬을 최대 8개 조회합니다.")
+    @GetMapping("/upcoming")
+    public ApplicationResponse<List<MusicalSimpleRes>> getUpcomingMusicals() {
+        List<MusicalSimpleRes> responses = musicalService.getUpcomingMusicals();
+        return ApplicationResponse.ok(responses);
+    }
 
 
 }

--- a/src/main/java/encore/server/domain/musical/dto/response/MusicalSimpleRes.java
+++ b/src/main/java/encore/server/domain/musical/dto/response/MusicalSimpleRes.java
@@ -1,0 +1,20 @@
+package encore.server.domain.musical.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record MusicalSimpleRes(
+        Long id,
+        String title,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        String location,
+        String imageUrl
+
+) {
+}

--- a/src/main/java/encore/server/domain/musical/entity/Musical.java
+++ b/src/main/java/encore/server/domain/musical/entity/Musical.java
@@ -55,4 +55,7 @@ public class Musical extends BaseTimeEntity {
     @OneToMany(mappedBy = "musical", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MusicalActor> musicalActors = new ArrayList<>();
 
+    @Column(nullable = false, columnDefinition = "boolean default false")
+    private boolean isFeatured; // 이달의 인기 뮤지컬 여부
+
 }

--- a/src/main/java/encore/server/domain/musical/repository/MusicalRepository.java
+++ b/src/main/java/encore/server/domain/musical/repository/MusicalRepository.java
@@ -10,8 +10,10 @@ import java.util.Optional;
 public interface MusicalRepository extends JpaRepository<Musical, Long> {
     List<Musical> findByTitleContaining(String keyword);
     Optional<Musical> findByIdAndDeletedAtIsNull(Long id);
+    List<Musical> findTop8ByIsFeaturedTrueOrderByStartDateAsc();
 
     @Query("SELECT m FROM Musical m WHERE m.title = :title AND m.deletedAt IS NULL")
     List<Musical> findByTitle(String title);
+
 
 }

--- a/src/main/java/encore/server/domain/musical/repository/MusicalRepository.java
+++ b/src/main/java/encore/server/domain/musical/repository/MusicalRepository.java
@@ -4,6 +4,7 @@ import encore.server.domain.musical.entity.Musical;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -14,6 +15,9 @@ public interface MusicalRepository extends JpaRepository<Musical, Long> {
 
     @Query("SELECT m FROM Musical m WHERE m.title = :title AND m.deletedAt IS NULL")
     List<Musical> findByTitle(String title);
+
+    @Query("SELECT m FROM Musical m WHERE m.startDate > :now AND m.deletedAt IS NULL ORDER BY m.startDate ASC")
+    List<Musical> findUpcomingMusicals(LocalDateTime now);
 
 
 }

--- a/src/main/java/encore/server/domain/musical/service/MusicalService.java
+++ b/src/main/java/encore/server/domain/musical/service/MusicalService.java
@@ -4,6 +4,7 @@ import encore.server.domain.musical.converter.MusicalConverter;
 import encore.server.domain.musical.dto.response.MusicalDetailRes;
 import encore.server.domain.musical.dto.response.MusicalRes;
 import encore.server.domain.musical.dto.response.MusicalSeriesRes;
+import encore.server.domain.musical.dto.response.MusicalSimpleRes;
 import encore.server.domain.musical.entity.Musical;
 import encore.server.domain.musical.repository.MusicalRepository;
 import encore.server.domain.review.entity.Review;
@@ -47,6 +48,20 @@ public class MusicalService {
                         .id(musical.getId())
                         .series(musical.getSeries())
                         .isCurrent(musical.getId().equals(musicalId)) // 현재 선택된 시리즈 표시
+                        .build())
+                .toList();
+    }
+
+    public List<MusicalSimpleRes> getFeaturedMusicals() {
+        List<Musical> musicals = musicalRepository.findTop8ByIsFeaturedTrueOrderByStartDateAsc();
+        return musicals.stream()
+                .map(musical -> MusicalSimpleRes.builder()
+                        .id(musical.getId())
+                        .title(musical.getTitle())
+                        .startDate(musical.getStartDate())
+                        .endDate(musical.getEndDate())
+                        .location(musical.getLocation())
+                        .imageUrl(musical.getImageUrl())
                         .build())
                 .toList();
     }

--- a/src/main/java/encore/server/domain/musical/service/MusicalService.java
+++ b/src/main/java/encore/server/domain/musical/service/MusicalService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -55,6 +56,23 @@ public class MusicalService {
     public List<MusicalSimpleRes> getFeaturedMusicals() {
         List<Musical> musicals = musicalRepository.findTop8ByIsFeaturedTrueOrderByStartDateAsc();
         return musicals.stream()
+                .map(musical -> MusicalSimpleRes.builder()
+                        .id(musical.getId())
+                        .title(musical.getTitle())
+                        .startDate(musical.getStartDate())
+                        .endDate(musical.getEndDate())
+                        .location(musical.getLocation())
+                        .imageUrl(musical.getImageUrl())
+                        .build())
+                .toList();
+    }
+
+    public List<MusicalSimpleRes> getUpcomingMusicals() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Musical> musicals = musicalRepository.findUpcomingMusicals(now);
+
+        return musicals.stream()
+                .limit(8)
                 .map(musical -> MusicalSimpleRes.builder()
                         .id(musical.getId())
                         .title(musical.getTitle())


### PR DESCRIPTION
## #️⃣연관된 이슈
> #66 

## 📝작업 내용
> 이달의 인기 뮤지컬 8개를 조회하며, 데이터베이스 상에서 is_featured값으로 구분하도록 설정하였습니다.
> 개봉 예정 뮤지컬을 임박한 순으로 8개 조회하는 API를 구현하였습니다.


## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
