### PR TITLE
Feat: 리뷰 좋아요 기획 변경 사항 반영

### DIFF
--- a/src/main/java/encore/server/domain/review/controller/ReviewController.java
+++ b/src/main/java/encore/server/domain/review/controller/ReviewController.java
@@ -73,7 +73,7 @@ public class ReviewController {
 
     @GetMapping("/popular-list")
     @Operation(summary = "인기 리뷰 리스트 조회", description = "인기 리뷰 리스트를 조회합니다.")
-    public ApplicationResponse<List<ReviewSimpleRes>> getPopularReviewList() {
+    public ApplicationResponse<List<ReviewPreviewRes>> getPopularReviewList() {
         return ApplicationResponse.ok(reviewService.getPopularReviewList());
     }
 

--- a/src/main/java/encore/server/domain/review/controller/ReviewController.java
+++ b/src/main/java/encore/server/domain/review/controller/ReviewController.java
@@ -2,12 +2,14 @@ package encore.server.domain.review.controller;
 
 import encore.server.domain.review.dto.request.ReviewReq;
 import encore.server.domain.review.dto.response.*;
+import encore.server.domain.review.enumerate.LikeType;
 import encore.server.domain.review.service.ReviewSearchService;
 import encore.server.domain.review.service.ReviewService;
 import encore.server.global.common.ApplicationResponse;
 import encore.server.global.util.redis.SearchLogRedis;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -64,9 +66,9 @@ public class ReviewController {
 
     @PatchMapping("/{review_id}/like")
     @Operation(summary = "리뷰 좋아요", description = "리뷰에 좋아요를 누릅니다.(좋아요 생성+취소)")
-    public ApplicationResponse<ReviewLikeRes> likeReview(@PathVariable("review_id") Long reviewId) {
+    public ApplicationResponse<ReviewLikeRes> likeReview(@PathVariable("review_id") Long reviewId, @Valid @RequestParam("like_type") LikeType likeType) {
         Long userId = getUserId();
-        return ApplicationResponse.ok(reviewService.likeReview(userId, reviewId));
+        return ApplicationResponse.ok(reviewService.likeReview(userId, reviewId, likeType));
     }
 
     @GetMapping("/popular-list")

--- a/src/main/java/encore/server/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/encore/server/domain/review/converter/ReviewConverter.java
@@ -5,11 +5,11 @@ import encore.server.domain.review.dto.response.*;
 import encore.server.domain.review.entity.ReviewData;
 import encore.server.domain.review.entity.ReviewTags;
 import encore.server.domain.review.entity.ViewImage;
+import encore.server.domain.review.enumerate.LikeType;
 import encore.server.domain.review.enumerate.Tag;
 import encore.server.domain.review.dto.request.ReviewReq;
 import encore.server.domain.review.entity.Review;
 import encore.server.domain.ticket.entity.Actor;
-import encore.server.domain.ticket.entity.Companion;
 import encore.server.domain.ticket.entity.Ticket;
 import encore.server.domain.user.entity.User;
 import encore.server.global.exception.ApplicationException;
@@ -44,7 +44,7 @@ public class ReviewConverter {
                 .build();
     }
 
-    public static ReviewDetailRes toReviewDetailRes(Review review, Boolean isUnlocked, Boolean isLike, String elapsedTime) {
+    public static ReviewDetailRes toReviewDetailRes(Review review, Boolean isUnlocked, LikeType likeType, String elapsedTime) {
         return ReviewDetailRes.builder()
                 .reviewId(review.getId())
                 .ticket(toTicketRes(review.getTicket()))
@@ -57,31 +57,9 @@ public class ReviewConverter {
                 .isMyReview(review.getUser().getId().equals(review.getUser().getId()))
                 .viewCount(review.getViewCount())
                 .elapsedTime(elapsedTime)
-                .likeRes(toReviewLikeRes(isLike, review.getLikeCount()))
+                .likeRes(ReviewLikeRes.of(likeType, review))
                 .build();
     }
-
-    public static ReviewSimpleRes toReviewSimpleRes(Review review, String elapsedTime, Boolean isLike) {
-        ReviewDataRes.Rating rating = review.getReviewData() != null ? toReviewDataRes(review.getReviewData()).rating() : null;
-        return ReviewSimpleRes.builder()
-                .reviewId(review.getId())
-                .userId(review.getUser().getId())
-                .title(review.getTitle())
-                .nickname(review.getUser().getNickName())
-                .elapsedTime(elapsedTime)
-                .viewCount(review.getViewCount())
-                .likeData(toReviewLikeRes(isLike, review.getLikeCount()))
-                .rating(rating)
-                .build();
-    }
-
-    public static ReviewLikeRes toReviewLikeRes(Boolean isLike, Long likeCount) {
-        return ReviewLikeRes.builder()
-                .isLike(isLike)
-                .likeCount(likeCount)
-                .build();
-    }
-
 
     private static List<ReviewTags> toReviewTags(List<String> tags, Review review) {
         try {
@@ -143,7 +121,7 @@ public class ReviewConverter {
                 .build();
     }
 
-    private static ReviewDataRes toReviewDataRes(ReviewData reviewData) {
+    public static ReviewDataRes toReviewDataRes(ReviewData reviewData) {
         return ReviewDataRes.builder()
                 .view(ReviewDataRes.View.builder()
                         .viewLevel(reviewData.getView().getViewLevel())

--- a/src/main/java/encore/server/domain/review/converter/ReviewConverter.java
+++ b/src/main/java/encore/server/domain/review/converter/ReviewConverter.java
@@ -1,15 +1,11 @@
 package encore.server.domain.review.converter;
 
 import encore.server.domain.review.dto.request.ReviewDataReq;
-import encore.server.domain.review.dto.response.*;
 import encore.server.domain.review.entity.ReviewData;
 import encore.server.domain.review.entity.ReviewTags;
-import encore.server.domain.review.entity.ViewImage;
-import encore.server.domain.review.enumerate.LikeType;
 import encore.server.domain.review.enumerate.Tag;
 import encore.server.domain.review.dto.request.ReviewReq;
 import encore.server.domain.review.entity.Review;
-import encore.server.domain.ticket.entity.Actor;
 import encore.server.domain.ticket.entity.Ticket;
 import encore.server.domain.user.entity.User;
 import encore.server.global.exception.ApplicationException;
@@ -32,35 +28,6 @@ public class ReviewConverter {
         return review;
     }
 
-    public static ViewImageRes toViewImageRes(List<ViewImage> viewImages) {
-        return ViewImageRes.builder()
-                .viewImages(viewImages.stream()
-                        .map(viewImage -> ViewImageRes.ViewImage.builder()
-                                .id(viewImage.getId())
-                                .url(viewImage.getUrl())
-                                .level(viewImage.getLevel())
-                                .build())
-                        .collect(Collectors.toList()))
-                .build();
-    }
-
-    public static ReviewDetailRes toReviewDetailRes(Review review, Boolean isUnlocked, LikeType likeType, String elapsedTime) {
-        return ReviewDetailRes.builder()
-                .reviewId(review.getId())
-                .ticket(toTicketRes(review.getTicket()))
-                .userId(review.getUser().getId())
-                .profileImageUrl(review.getUser().getProfileImageUrl())
-                .title(review.getTitle())
-                .tags(tagToString(review.getTags()))
-                .reviewDataRes(toReviewDataRes(review.getReviewData()))
-                .isUnlocked(isUnlocked)
-                .isMyReview(review.getUser().getId().equals(review.getUser().getId()))
-                .viewCount(review.getViewCount())
-                .elapsedTime(elapsedTime)
-                .likeRes(ReviewLikeRes.of(likeType, review))
-                .build();
-    }
-
     private static List<ReviewTags> toReviewTags(List<String> tags, Review review) {
         try {
             return tags.stream()
@@ -72,27 +39,6 @@ public class ReviewConverter {
         } catch (IllegalArgumentException e) {
             throw new ApplicationException(ErrorCode.REVIEW_TAG_NOT_FOUND_EXCEPTION);
         }
-    }
-
-    private static List<String> tagToString(List<ReviewTags> tags) {
-        return tags.stream()
-                .map(reviewTag -> reviewTag.getTag().name())
-                .collect(Collectors.toList());
-    }
-
-    //Todo: 티켓 완성 시 패키지 옮기기
-    private static ReviewDetailRes.TicketRes toTicketRes(Ticket ticket) {
-        return ReviewDetailRes.TicketRes.builder()
-                .ticketId(ticket.getId())
-                .ticketTitle(ticket.getTitle())
-                .seat(ticket.getSeat())
-                .viewedDate(ticket.getViewedDate())
-                .imageUrl(ticket.getTicketImageUrl())
-                .actors(ticket.getActors()
-                        .stream()
-                        .map(Actor::getName)
-                        .collect(Collectors.toList()))
-                .build();
     }
 
     private static ReviewData toReviewData(ReviewDataReq req){
@@ -117,32 +63,6 @@ public class ReviewConverter {
                         .performanceRating(req.rating().performanceRating())
                         .totalRating(req.rating().totalRating())
                         .ratingReview(req.rating().ratingReview())
-                        .build())
-                .build();
-    }
-
-    public static ReviewDataRes toReviewDataRes(ReviewData reviewData) {
-        return ReviewDataRes.builder()
-                .view(ReviewDataRes.View.builder()
-                        .viewLevel(reviewData.getView().getViewLevel())
-                        .viewReview(reviewData.getView().getViewReview())
-                        .build())
-                .sound(ReviewDataRes.Sound.builder()
-                        .soundLevel(reviewData.getSound().getSoundLevel())
-                        .soundReview(reviewData.getSound().getSoundReview())
-                        .build())
-                .facility(ReviewDataRes.Facility.builder()
-                        .facilityLevel(reviewData.getFacility().getFacilityLevel())
-                        .facilityReview(reviewData.getFacility().getFacilityReview())
-                        .build())
-                .rating(ReviewDataRes.Rating.builder()
-                        .numberRating(reviewData.getRating().getNumberRating())
-                        .storyRating(reviewData.getRating().getStoryRating())
-                        .revisitRating(reviewData.getRating().getRevisitRating())
-                        .actorRating(reviewData.getRating().getActorRating())
-                        .performanceRating(reviewData.getRating().getPerformanceRating())
-                        .totalRating(reviewData.getRating().getTotalRating())
-                        .ratingReview(reviewData.getRating().getRatingReview())
                         .build())
                 .build();
     }

--- a/src/main/java/encore/server/domain/review/dto/response/ReviewDataRes.java
+++ b/src/main/java/encore/server/domain/review/dto/response/ReviewDataRes.java
@@ -2,6 +2,7 @@ package encore.server.domain.review.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import encore.server.domain.review.entity.ReviewData;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -77,5 +78,31 @@ public record ReviewDataRes(
             @Schema(description = "평점 리뷰", example = "평점이 너무 좋았어요!")
             String ratingReview
     ) {
+    }
+
+    public static ReviewDataRes of(ReviewData reviewData) {
+        return ReviewDataRes.builder()
+                .view(ReviewDataRes.View.builder()
+                        .viewLevel(reviewData.getView().getViewLevel())
+                        .viewReview(reviewData.getView().getViewReview())
+                        .build())
+                .sound(ReviewDataRes.Sound.builder()
+                        .soundLevel(reviewData.getSound().getSoundLevel())
+                        .soundReview(reviewData.getSound().getSoundReview())
+                        .build())
+                .facility(ReviewDataRes.Facility.builder()
+                        .facilityLevel(reviewData.getFacility().getFacilityLevel())
+                        .facilityReview(reviewData.getFacility().getFacilityReview())
+                        .build())
+                .rating(ReviewDataRes.Rating.builder()
+                        .numberRating(reviewData.getRating().getNumberRating())
+                        .storyRating(reviewData.getRating().getStoryRating())
+                        .revisitRating(reviewData.getRating().getRevisitRating())
+                        .actorRating(reviewData.getRating().getActorRating())
+                        .performanceRating(reviewData.getRating().getPerformanceRating())
+                        .totalRating(reviewData.getRating().getTotalRating())
+                        .ratingReview(reviewData.getRating().getRatingReview())
+                        .build())
+                .build();
     }
 }

--- a/src/main/java/encore/server/domain/review/dto/response/ReviewDetailRes.java
+++ b/src/main/java/encore/server/domain/review/dto/response/ReviewDetailRes.java
@@ -2,11 +2,17 @@ package encore.server.domain.review.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import encore.server.domain.review.entity.Review;
+import encore.server.domain.review.entity.ReviewTags;
+import encore.server.domain.review.enumerate.LikeType;
+import encore.server.domain.ticket.entity.Actor;
+import encore.server.domain.ticket.entity.Ticket;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -70,5 +76,41 @@ public record ReviewDetailRes(
             @Schema(description = "배우 리스트", example = "[\"김뮤뮤\", \"이뮤뮤\"]")
             List<String> actors
     ) {
+        private static ReviewDetailRes.TicketRes of(Ticket ticket) {
+            return ReviewDetailRes.TicketRes.builder()
+                    .ticketId(ticket.getId())
+                    .ticketTitle(ticket.getTitle())
+                    .seat(ticket.getSeat())
+                    .viewedDate(ticket.getViewedDate())
+                    .imageUrl(ticket.getTicketImageUrl())
+                    .actors(ticket.getActors()
+                            .stream()
+                            .map(Actor::getName)
+                            .collect(Collectors.toList()))
+                    .build();
+        }
+    }
+
+    private static List<String> tagToString(List<ReviewTags> tags) {
+        return tags.stream()
+                .map(reviewTag -> reviewTag.getTag().name())
+                .collect(Collectors.toList());
+    }
+
+    public static ReviewDetailRes of(Review review, Boolean isUnlocked, LikeType likeType, String elapsedTime) {
+        return ReviewDetailRes.builder()
+                .reviewId(review.getId())
+                .ticket(TicketRes.of(review.getTicket()))
+                .userId(review.getUser().getId())
+                .profileImageUrl(review.getUser().getProfileImageUrl())
+                .title(review.getTitle())
+                .tags(tagToString(review.getTags()))
+                .reviewDataRes(ReviewDataRes.of(review.getReviewData()))
+                .isUnlocked(isUnlocked)
+                .isMyReview(review.getUser().getId().equals(review.getUser().getId()))
+                .viewCount(review.getViewCount())
+                .elapsedTime(elapsedTime)
+                .likeRes(ReviewLikeRes.of(likeType, review))
+                .build();
     }
 }

--- a/src/main/java/encore/server/domain/review/dto/response/ReviewLikeRes.java
+++ b/src/main/java/encore/server/domain/review/dto/response/ReviewLikeRes.java
@@ -2,16 +2,49 @@ package encore.server.domain.review.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import encore.server.domain.review.entity.Review;
+import encore.server.domain.review.enumerate.LikeType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record ReviewLikeRes(
-        @Schema(description = "좋아요 여부", example = "true")
-        Boolean isLike,
+        @Schema(description = "좋아요 종류", example = "FOLLOW_UP_RECOMMENDATION | FULL_OF_TIPS | THOROUGH_ANALYSIS")
+        LikeType likeType,
 
-        @Schema(description = "좋아요 수", example = "100")
-        Long likeCount
+        LikeCountRes likeCountRes
+
 ) {
+        @Builder
+        @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+        public record LikeCountRes(
+
+                @Schema(description = "총 좋아요 개수", example = "100")
+                Long totalLikeCount,
+                @Schema(description = "후속 추천 좋아요 개수", example = "100")
+                Long followUpLikeCount,
+
+                @Schema(description = "꿀팁 가득 좋아요 개수", example = "100")
+                Long fullOfTipsLikeCount,
+
+                @Schema(description = "꼼꼼 분석 좋아요 개수", example = "100")
+                Long thoroughAnalysisLikeCount
+        ){
+                public static LikeCountRes of(Review review) {
+                        return LikeCountRes.builder()
+                                .totalLikeCount(review.getLikeCount())
+                                .followUpLikeCount(review.getFollowUpLikeCount())
+                                .fullOfTipsLikeCount(review.getFullOfTipsLikeCount())
+                                .thoroughAnalysisLikeCount(review.getThoroughAnalysisLikeCount())
+                                .build();
+                }
+        }
+
+        public static ReviewLikeRes of(LikeType likeType, Review review) {
+                return ReviewLikeRes.builder()
+                        .likeType(likeType != null ? likeType : LikeType.NONE)
+                        .likeCountRes(LikeCountRes.of(review))
+                        .build();
+        }
 }

--- a/src/main/java/encore/server/domain/review/dto/response/ReviewPreviewRes.java
+++ b/src/main/java/encore/server/domain/review/dto/response/ReviewPreviewRes.java
@@ -1,0 +1,68 @@
+package encore.server.domain.review.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import encore.server.domain.review.entity.Review;
+import encore.server.domain.review.enumerate.LikeType;
+import encore.server.domain.ticket.entity.Actor;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ReviewPreviewRes(
+        @Schema(description = "리뷰 ID", example = "1")
+        Long reviewId,
+
+        @Schema(description = "유저 ID", example = "1")
+        Long userId,
+
+        @Schema(description = "리뷰 제목", example = "위키드 리뷰")
+        String title,
+
+        @Schema(description = "닉네임", example = "김철수")
+        String nickname,
+
+        @Schema(description = "업로드 시점", example = "11분 전")
+        String elapsedTime,
+
+        @Schema(description = "리뷰 조회수", example = "100")
+        Long viewCount,
+
+        @Schema(description = "리뷰 좋아요 데이터")
+        ReviewLikeRes likeData,
+
+        @Schema(description = "리뷰 총평점과 내용")
+        ReviewDataRes.Rating rating,
+
+        @Schema(description = "장소")
+        String location,
+
+        @Schema(description = "좌석")
+        String seat,
+
+        @Schema(description = "배우", example = "김철수")
+        List<String> actors
+) {
+
+    public static ReviewPreviewRes of(Review review, String elapsedTime, LikeType likeType) {
+        return ReviewPreviewRes.builder()
+                .reviewId(review.getId())
+                .userId(review.getUser().getId())
+                .title(review.getTitle())
+                .nickname(review.getUser().getNickName())
+                .elapsedTime(elapsedTime)
+                .viewCount(review.getViewCount())
+                .likeData(ReviewLikeRes.of(likeType, review))
+                .rating(ReviewDataRes.of(review.getReviewData()).rating())
+                .location(review.getTicket().getMusical().getLocation())
+                .seat(review.getTicket().getSeat())
+                .actors(review.getTicket().getActors().stream()
+                        .map(Actor::getName)
+                        .toList())
+                .build();
+
+    }
+}

--- a/src/main/java/encore/server/domain/review/dto/response/ReviewSimpleRes.java
+++ b/src/main/java/encore/server/domain/review/dto/response/ReviewSimpleRes.java
@@ -2,8 +2,11 @@ package encore.server.domain.review.dto.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import encore.server.domain.review.entity.Review;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+
+import static encore.server.domain.review.converter.ReviewConverter.toReviewDataRes;
 
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -26,10 +29,23 @@ public record ReviewSimpleRes(
         @Schema(description = "리뷰 조회수", example = "100")
         Long viewCount,
 
-        @Schema(description = "리뷰 좋아요 데이터")
-        ReviewLikeRes likeData,
+        @Schema(description = "리뷰 좋아요 개수", example = "100")
+        Long likeCount,
 
         @Schema(description = "리뷰 총평점과 내용")
         ReviewDataRes.Rating rating
 ) {
+        public static ReviewSimpleRes of(Review review, String elapsedTime) {
+                ReviewDataRes.Rating rating = review.getReviewData() != null ? toReviewDataRes(review.getReviewData()).rating() : null;
+                return ReviewSimpleRes.builder()
+                        .reviewId(review.getId())
+                        .userId(review.getUser().getId())
+                        .title(review.getTitle())
+                        .nickname(review.getUser().getNickName())
+                        .elapsedTime(elapsedTime)
+                        .viewCount(review.getViewCount())
+                        .likeCount(review.getLikeCount())
+                        .rating(rating)
+                        .build();
+        }
 }

--- a/src/main/java/encore/server/domain/review/dto/response/ReviewSimpleRes.java
+++ b/src/main/java/encore/server/domain/review/dto/response/ReviewSimpleRes.java
@@ -6,8 +6,6 @@ import encore.server.domain.review.entity.Review;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
-import static encore.server.domain.review.converter.ReviewConverter.toReviewDataRes;
-
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public record ReviewSimpleRes(
@@ -36,7 +34,7 @@ public record ReviewSimpleRes(
         ReviewDataRes.Rating rating
 ) {
         public static ReviewSimpleRes of(Review review, String elapsedTime) {
-                ReviewDataRes.Rating rating = review.getReviewData() != null ? toReviewDataRes(review.getReviewData()).rating() : null;
+                ReviewDataRes.Rating rating = review.getReviewData() != null ? ReviewDataRes.of(review.getReviewData()).rating() : null;
                 return ReviewSimpleRes.builder()
                         .reviewId(review.getId())
                         .userId(review.getUser().getId())

--- a/src/main/java/encore/server/domain/review/dto/response/ViewImageRes.java
+++ b/src/main/java/encore/server/domain/review/dto/response/ViewImageRes.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Builder
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
@@ -23,5 +24,17 @@ public record ViewImageRes(
             @Schema(description = "시야 레벨", example = "3")
             Long level
     ) {
+    }
+
+    public static ViewImageRes of(List<encore.server.domain.review.entity.ViewImage> viewImages) {
+        return ViewImageRes.builder()
+                .viewImages(viewImages.stream()
+                        .map(viewImage -> ViewImageRes.ViewImage.builder()
+                                .id(viewImage.getId())
+                                .url(viewImage.getUrl())
+                                .level(viewImage.getLevel())
+                                .build())
+                        .collect(Collectors.toList()))
+                .build();
     }
 }

--- a/src/main/java/encore/server/domain/review/entity/Review.java
+++ b/src/main/java/encore/server/domain/review/entity/Review.java
@@ -1,5 +1,6 @@
 package encore.server.domain.review.entity;
 
+import encore.server.domain.review.enumerate.LikeType;
 import encore.server.domain.ticket.entity.Ticket;
 import encore.server.domain.user.entity.User;
 import encore.server.global.common.BaseTimeEntity;
@@ -39,6 +40,15 @@ public class Review extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "bigint default 0")
     private Long likeCount;
 
+    @Column(nullable = false, columnDefinition = "bigint default 0")
+    private Long followUpLikeCount;
+
+    @Column(nullable = false, columnDefinition = "bigint default 0")
+    private Long fullOfTipsLikeCount;
+
+    @Column(nullable = false, columnDefinition = "bigint default 0")
+    private Long thoroughAnalysisLikeCount;
+
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReviewTags> tags;
 
@@ -56,6 +66,9 @@ public class Review extends BaseTimeEntity {
         this.tags = tags;
         this.reviewData = reviewData;
         this.viewCount = 0L;
+        this.followUpLikeCount = 0L;
+        this.fullOfTipsLikeCount = 0L;
+        this.thoroughAnalysisLikeCount = 0L;
         this.likeCount = 0L;
     }
 
@@ -63,7 +76,21 @@ public class Review extends BaseTimeEntity {
         this.tags = reviewTags;
     }
 
-    public void setLikeCount(Long likeCount) {
+    public void setLikeCount(LikeType likeType, Long likeCount) {
+       switch (likeType) {
+           case FOLLOW_UP_RECOMMENDATION:
+               this.followUpLikeCount = likeCount;
+               break;
+           case FULL_OF_TIPS:
+               this.fullOfTipsLikeCount = likeCount;
+               break;
+           case THOROUGH_ANALYSIS:
+               this.thoroughAnalysisLikeCount = likeCount;
+               break;
+       }
+    }
+
+    public void setTotalLikeCount(Long likeCount) {
         this.likeCount = likeCount;
     }
 }

--- a/src/main/java/encore/server/domain/review/entity/ReviewLike.java
+++ b/src/main/java/encore/server/domain/review/entity/ReviewLike.java
@@ -1,5 +1,6 @@
 package encore.server.domain.review.entity;
 
+import encore.server.domain.review.enumerate.LikeType;
 import encore.server.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -23,18 +24,17 @@ public class ReviewLike {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(nullable = false, columnDefinition = "boolean default false")
-    private Boolean isLike;
+    @Enumerated(EnumType.STRING)
+    private LikeType likeType;
 
     @Builder
-    public ReviewLike(Review review, User user) {
+    public ReviewLike(Review review, User user, LikeType likeType) {
         this.review = review;
         this.user = user;
-        this.isLike = true;
+        this.likeType = likeType;
     }
 
-    public Boolean toggleLike(Boolean isLike) {
-        this.isLike = !isLike;
-        return isLike;
+    public void toggleLike(LikeType likeType) {
+        this.likeType = this.likeType == likeType ? null : likeType;
     }
 }

--- a/src/main/java/encore/server/domain/review/enumerate/LikeType.java
+++ b/src/main/java/encore/server/domain/review/enumerate/LikeType.java
@@ -1,0 +1,17 @@
+package encore.server.domain.review.enumerate;
+
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum LikeType {
+    FOLLOW_UP_RECOMMENDATION("후속추천"),
+    FULL_OF_TIPS("꿀팁가득"),
+    THOROUGH_ANALYSIS("꼼꼼분석"),
+    NONE("좋아요 없음");
+
+    private final String name;
+}
+

--- a/src/main/java/encore/server/domain/review/mapping/LikeTypeMapping.java
+++ b/src/main/java/encore/server/domain/review/mapping/LikeTypeMapping.java
@@ -1,0 +1,7 @@
+package encore.server.domain.review.mapping;
+
+import encore.server.domain.review.enumerate.LikeType;
+
+public interface LikeTypeMapping {
+    LikeType getLikeType();
+}

--- a/src/main/java/encore/server/domain/review/repository/ReviewLikeRepository.java
+++ b/src/main/java/encore/server/domain/review/repository/ReviewLikeRepository.java
@@ -2,6 +2,8 @@ package encore.server.domain.review.repository;
 
 import encore.server.domain.review.entity.Review;
 import encore.server.domain.review.entity.ReviewLike;
+import encore.server.domain.review.enumerate.LikeType;
+import encore.server.domain.review.mapping.LikeTypeMapping;
 import encore.server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -9,6 +11,7 @@ import java.util.Optional;
 
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
     Optional<ReviewLike> findByReviewAndUser(Review review, User user);
-    Long countByReviewAndIsLikeTrue(Review review);
-    boolean existsByReviewAndUserAndIsLikeTrue(Review review, User user);
+    Long countByReview(Review review);
+    Optional<LikeTypeMapping> findLikeTypeByReviewAndUser(Review review, User user);
+    long countByReviewAndLikeType(Review review, LikeType likeType);
 }

--- a/src/main/java/encore/server/domain/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/encore/server/domain/review/repository/ReviewRepositoryImpl.java
@@ -67,7 +67,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
         return queryFactory
                 .selectFrom(review)
                 .where(review.deletedAt.isNull())
-                .orderBy(review.likeCount.desc())
+                .orderBy(review.likeCount.desc(), review.createdAt.desc())
                 .limit(5)
                 .fetch();
     }

--- a/src/main/java/encore/server/domain/review/service/ReviewService.java
+++ b/src/main/java/encore/server/domain/review/service/ReviewService.java
@@ -217,7 +217,7 @@ public class ReviewService {
         }
     }
 
-    public List<ReviewSimpleRes> getPopularReviewList() {
+    public List<ReviewPreviewRes> getPopularReviewList() {
         // business logic: get popular review list
         List<Review> reviews = reviewRepository.findPopularReviews();
         if (reviews.isEmpty()) {
@@ -225,8 +225,13 @@ public class ReviewService {
         }
 
         // return: popular review list
-       return reviews.stream()
-                .map(this::convertToReviewSimpleRes)
+        return reviews.stream()
+                .map(r -> {
+                    String elapsedTime = getElapsedTime(ChronoUnit.MINUTES.between(r.getCreatedAt(), LocalDateTime.now()));
+                    Optional<LikeTypeMapping> likeTypeMapping = reviewLikeRepository.findLikeTypeByReviewAndUser(r, r.getUser());
+                    LikeType likeType = likeTypeMapping.map(LikeTypeMapping::getLikeType).orElse(LikeType.NONE);
+                    return ReviewPreviewRes.of(r, elapsedTime, likeType);
+                })
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/encore/server/domain/review/service/ReviewService.java
+++ b/src/main/java/encore/server/domain/review/service/ReviewService.java
@@ -73,7 +73,7 @@ public class ReviewService {
 
 
         // return: review response
-        return ReviewConverter.toReviewDetailRes(review, true, likeType, elapsedTime);
+        return ReviewDetailRes.of(review, true, likeType, elapsedTime);
     }
 
     public ViewImageRes viewImage(Long cycle) {
@@ -82,7 +82,7 @@ public class ReviewService {
         List<ViewImage> viewImages = viewImageRepository.findByIdBetween(start, start + 3);
 
         //return: view image response
-        return ReviewConverter.toViewImageRes(viewImages);
+        return ViewImageRes.of(viewImages);
     }
 
     public ReviewDetailRes getReview(Long userId, Long reviewId) {
@@ -111,7 +111,7 @@ public class ReviewService {
         String elapsedTime = getElapsedTime(ChronoUnit.MINUTES.between(review.getCreatedAt(), LocalDateTime.now()));
 
         // return: review detail response
-        return ReviewConverter.toReviewDetailRes(review, isUnlocked, likeType, elapsedTime);
+        return ReviewDetailRes.of(review, isUnlocked, likeType, elapsedTime);
     }
 
     @Transactional

--- a/src/main/java/encore/server/global/exception/ErrorCode.java
+++ b/src/main/java/encore/server/global/exception/ErrorCode.java
@@ -46,6 +46,7 @@ public enum ErrorCode {
     REVIEW_TAG_NOT_FOUND_EXCEPTION(HttpStatus.BAD_REQUEST, 8002, "존재하지 않는 태그입니다."),
     REVIEW_LOCKED_EXCEPTION(HttpStatus.FORBIDDEN, 8003, "리뷰가 잠겨있습니다."),
     REVIEW_ALREADY_UNLOCKED_EXCEPTION(HttpStatus.BAD_REQUEST, 8004, "이미 리뷰 잠금이 해제되었습니다."),
+    REVIEW_LIKE_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, 8007, "존재하지 않는 리뷰 좋아요입니다."),
 
     // 9000: Mission Error
     MISSION_NOT_FOUND_EXCEPTION(HttpStatus.NOT_FOUND, 9000, "존재하지 않는 미션입니다."),


### PR DESCRIPTION
## #️⃣연관된 이슈
> ex) #이슈번호, #이슈번호
- #70 

## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

기존 일반 좋아요 방식에서 사진처럼 좋아요를 세가지로 나누어 관리할 수 있도록 했습니다!
<img width="305" alt="스크린샷 2025-01-03 오후 10 38 36" src="https://github.com/user-attachments/assets/478d2c0e-26e0-4a05-88c6-cefe90431c6b" />

### 스크린샷 (선택)
<img width="1431" alt="스크린샷 2025-01-03 오후 10 39 23" src="https://github.com/user-attachments/assets/17719544-f99a-4017-8cac-aa0a9eb0f946" />


## 💬리뷰 요구사항(선택)
- dto 변환 컨버터는 dto로 이동해주었습니다.
