### PR TITLE
Feat: Jsoup, Selenium을 이용한 뮤지컬 정보 크롤링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,11 @@ dependencies {
 
     // Komoran
     implementation 'com.github.shin285:KOMORAN:3.3.9'
+
+    // Jsoup
+    implementation 'org.jsoup:jsoup:1.15.3'
+    implementation 'org.seleniumhq.selenium:selenium-java:4.0.0'
+    implementation 'io.github.bonigarcia:webdrivermanager:5.0.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/encore/server/domain/musical/controller/MusicalController.java
+++ b/src/main/java/encore/server/domain/musical/controller/MusicalController.java
@@ -4,14 +4,12 @@ import encore.server.domain.musical.dto.response.MusicalDetailRes;
 import encore.server.domain.musical.dto.response.MusicalRes;
 import encore.server.domain.musical.dto.response.MusicalSeriesRes;
 import encore.server.domain.musical.dto.response.MusicalSimpleRes;
-import encore.server.domain.musical.entity.Musical;
 import encore.server.domain.musical.service.MusicalService;
-import encore.server.domain.review.dto.response.ReviewDetailRes;
 import encore.server.global.common.ApplicationResponse;
+import encore.server.domain.musical.service.MusicalListService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -23,6 +21,7 @@ import java.util.List;
 @Tag(name = "Musical", description = "뮤지컬 API")
 public class MusicalController {
     private final MusicalService musicalService;
+    private final MusicalListService musicalListService;
 
     @Operation(summary = "뮤지컬 검색", description = "뮤지컬을 키워드로 검색합니다.")
     @GetMapping("/search")
@@ -58,6 +57,12 @@ public class MusicalController {
         return ApplicationResponse.ok(responses);
     }
 
-
+    // Todo: prod환경 테스트 후 스케줄링 할 예정
+    @Operation(summary = "뮤지컬 정보 크롤링 및 저장", description = "Interpark 뮤지컬 페이지에서 뮤지컬 정보를 크롤링하여 저장합니다.")
+    @GetMapping("/crawling")
+    public ApplicationResponse<String> crawlingMusicalInfo() {
+        musicalListService.crawlingMusicalInfo();
+        return ApplicationResponse.ok("크롤링 완료");
+    }
 }
 

--- a/src/main/java/encore/server/domain/musical/converter/MusicalConverter.java
+++ b/src/main/java/encore/server/domain/musical/converter/MusicalConverter.java
@@ -15,7 +15,9 @@ public class MusicalConverter {
                 .title(musical.getTitle())
                 .series(musical.getSeries())
                 .location(musical.getLocation())
-                .showTimes(musical.getShowTimes())
+                .showTimes(musical.getShowTimes().stream()
+                        .map(showTime -> showTime.getDay() + " " + showTime.getTime())
+                        .collect(Collectors.toList()))
                 .build();
     }
 

--- a/src/main/java/encore/server/domain/musical/dto/response/MusicalDetailRes.java
+++ b/src/main/java/encore/server/domain/musical/dto/response/MusicalDetailRes.java
@@ -17,7 +17,7 @@ public record MusicalDetailRes(
         LocalDateTime endDate,
         String location,
         Long runningTime,
-        Long age,
+        String age,
         Long series,
         String imageUrl,
         List<MusicalActorRes> actors

--- a/src/main/java/encore/server/domain/musical/entity/Musical.java
+++ b/src/main/java/encore/server/domain/musical/entity/Musical.java
@@ -4,6 +4,7 @@ package encore.server.domain.musical.entity;
 import encore.server.global.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
@@ -47,10 +48,8 @@ public class Musical extends BaseTimeEntity {
     @Column(columnDefinition = "text")
     private String imageUrl;
 
-    @ElementCollection(fetch = FetchType.EAGER)
-    @CollectionTable(name = "musical_show_times", joinColumns = @JoinColumn(name = "musical_id"))
-    @Column(name = "show_time")
-    private List<String> showTimes = new ArrayList<>();
+    @OneToMany(mappedBy = "musical", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ShowTime> showTimes = new ArrayList<>();
 
     @OneToMany(mappedBy = "musical", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MusicalActor> musicalActors = new ArrayList<>();
@@ -58,4 +57,26 @@ public class Musical extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "boolean default false")
     private boolean isFeatured; // 이달의 인기 뮤지컬 여부
 
+    @Column(columnDefinition = "varchar(255)")
+    private String interparkId;
+
+    @Builder
+    public Musical(String title, LocalDateTime startDate, LocalDateTime endDate, String location, Long runningTime, Long age, Long series, String imageUrl, List<ShowTime> showTimes, List<MusicalActor> musicalActors, boolean isFeatured, String interparkId) {
+        this.title = title;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.location = location;
+        this.runningTime = runningTime;
+        this.age = age;
+        this.series = series != null ? series : 1L;
+        this.imageUrl = imageUrl;
+        this.showTimes = showTimes;
+        this.musicalActors = musicalActors;
+        this.isFeatured = isFeatured;
+        this.interparkId = interparkId;
+    }
+
+    public void addShowTime(ShowTime showTime) {
+        this.showTimes.add(showTime);
+    }
 }

--- a/src/main/java/encore/server/domain/musical/entity/Musical.java
+++ b/src/main/java/encore/server/domain/musical/entity/Musical.java
@@ -39,8 +39,8 @@ public class Musical extends BaseTimeEntity {
     @Column(nullable = false, columnDefinition = "bigint")
     private Long runningTime;
 
-    @Column(nullable = false, columnDefinition = "bigint")
-    private Long age;
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    private String age;
 
     @Column(nullable = false, columnDefinition = "bigint")
     private Long series;
@@ -61,7 +61,7 @@ public class Musical extends BaseTimeEntity {
     private String interparkId;
 
     @Builder
-    public Musical(String title, LocalDateTime startDate, LocalDateTime endDate, String location, Long runningTime, Long age, Long series, String imageUrl, List<ShowTime> showTimes, List<MusicalActor> musicalActors, boolean isFeatured, String interparkId) {
+    public Musical(String title, LocalDateTime startDate, LocalDateTime endDate, String location, Long runningTime, String age, Long series, String imageUrl, List<ShowTime> showTimes, List<MusicalActor> musicalActors, boolean isFeatured, String interparkId) {
         this.title = title;
         this.startDate = startDate;
         this.endDate = endDate;
@@ -76,6 +76,9 @@ public class Musical extends BaseTimeEntity {
         this.interparkId = interparkId;
     }
 
+    public void addMusicalActors(MusicalActor musicalActor) {
+        this.musicalActors.add(musicalActor);
+    }
     public void addShowTime(ShowTime showTime) {
         this.showTimes.add(showTime);
     }

--- a/src/main/java/encore/server/domain/musical/entity/ShowTime.java
+++ b/src/main/java/encore/server/domain/musical/entity/ShowTime.java
@@ -1,0 +1,35 @@
+package encore.server.domain.musical.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ShowTime {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(nullable = false, columnDefinition = "bigint")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "musical_id", nullable = false)
+    private Musical musical;
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    private String day;
+
+    @Column(nullable = false, columnDefinition = "varchar(255)")
+    private String time;
+
+    @Builder
+    public ShowTime(Musical musical, String day, String time) {
+        this.musical = musical;
+        this.day = day;
+        this.time = time;
+    }
+}

--- a/src/main/java/encore/server/domain/musical/entity/ShowTime.java
+++ b/src/main/java/encore/server/domain/musical/entity/ShowTime.java
@@ -1,5 +1,6 @@
 package encore.server.domain.musical.entity;
 
+import encore.server.domain.musical.enumerate.Day;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -20,14 +21,15 @@ public class ShowTime {
     @JoinColumn(name = "musical_id", nullable = false)
     private Musical musical;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false, columnDefinition = "varchar(255)")
-    private String day;
+    private Day day;
 
     @Column(nullable = false, columnDefinition = "varchar(255)")
     private String time;
 
     @Builder
-    public ShowTime(Musical musical, String day, String time) {
+    public ShowTime(Musical musical, Day day, String time) {
         this.musical = musical;
         this.day = day;
         this.time = time;

--- a/src/main/java/encore/server/domain/musical/enumerate/Day.java
+++ b/src/main/java/encore/server/domain/musical/enumerate/Day.java
@@ -1,0 +1,17 @@
+package encore.server.domain.musical.enumerate;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public enum Day {
+    MONDAY("월요일"),
+    TUESDAY("화요일"),
+    WEDNESDAY("수요일"),
+    THURSDAY("목요일"),
+    FRIDAY("금요일"),
+    SATURDAY("토요일"),
+    SUNDAY("일요일"),
+    HOLIDAY("공휴일");
+
+    private final String day;
+}

--- a/src/main/java/encore/server/domain/musical/repository/MusicalRepository.java
+++ b/src/main/java/encore/server/domain/musical/repository/MusicalRepository.java
@@ -17,5 +17,5 @@ public interface MusicalRepository extends JpaRepository<Musical, Long> {
     @Query("SELECT m FROM Musical m WHERE m.startDate > :now AND m.deletedAt IS NULL ORDER BY m.startDate ASC")
     List<Musical> findUpcomingMusicals(LocalDateTime now);
 
-
+    boolean existsByInterparkId(String interparkId);
 }

--- a/src/main/java/encore/server/domain/musical/service/MusicalInfoService.java
+++ b/src/main/java/encore/server/domain/musical/service/MusicalInfoService.java
@@ -1,0 +1,131 @@
+package encore.server.domain.musical.service;
+
+import encore.server.global.common.ParsingShowTime;
+import encore.server.global.config.SeleniumConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MusicalInfoService {
+    private final SeleniumConfig seleniumConfig;
+    private final ParsingShowTime parsingShowTime;
+
+    @Value("${jsoup.goods.url}")
+    private String goodsUrl;
+
+    /**
+     * 뮤지컬 상세 정보를 가져오는 메서드
+     * @param groupId
+     */
+    public void fetchMusicalDetails(String groupId) {
+        String url = goodsUrl + groupId;
+        WebDriver driver = new ChromeDriver();
+        WebDriverWait wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+
+        try {
+            // 페이지로 이동
+            log.info("Navigating to the URL...");
+            driver.get(url);
+
+            // 페이지가 완전히 로드될 때까지 대기
+            log.info("Waiting for the page to load...");
+            wait.until(ExpectedConditions.presenceOfElementLocated(By.cssSelector("h2.prdTitle")));
+
+            // 뮤지컬 제목 가져오기
+            WebElement titleElement = driver.findElement(By.cssSelector("h2.prdTitle"));
+            String title = titleElement.getText();
+            log.info("뮤지컬 제목: {}", title);
+
+            // 뮤지컬 이미지 URL 가져오기
+            WebElement imgElement = driver.findElement(By.cssSelector("div.posterBoxTop img.posterBoxImage"));
+            String imageUrl = imgElement != null ? imgElement.getAttribute("src") : null;
+            log.info("뮤지컬 이미지 URL: {}", imageUrl);
+
+            // 장소 가져오기
+            WebElement locationElement = driver.findElement(By.xpath("//li[contains(@class, 'infoItem')]//strong[contains(text(), '장소')]/following-sibling::div//a"));
+            String location = locationElement.getText().replaceAll("\\(.*?\\)", "").trim();
+            log.info("장소: {}", location);
+
+            // 공연 기간 가져오기
+            WebElement periodElement = driver.findElement(By.xpath("//li[contains(@class, 'infoItem')]//strong[contains(text(), '공연기간')]/following-sibling::div//p[@class='infoText']"));
+            String performancePeriod = periodElement.getText();
+            String[] periodSplit = performancePeriod.split("~");
+            String startDate = periodSplit[0].trim();
+            String endDate = periodSplit[1].trim();
+            log.info("공연 시작일: {}", parseDate(startDate));
+            log.info("공연 종료일: {}", parseDate(endDate));
+
+            // 공연 시간 가져오기
+            WebElement runningTimeElement = driver.findElement(By.xpath("//li[contains(@class, 'infoItem')]//strong[contains(text(), '공연시간')]/following-sibling::div//p[@class='infoText']"));
+            Long runningTime = Long.parseLong(runningTimeElement.getText().replaceAll("\\(.*?\\)", "").replace("분", "").trim());
+            log.info("공연 시간 (분): {}", runningTime);
+
+            // 관람 연령 가져오기
+            WebElement ageElement = driver.findElement(By.xpath("//li[contains(@class, 'infoItem')]//strong[contains(text(), '관람연령')]/following-sibling::div//p[@class='infoText']"));
+            Long age = Long.parseLong(ageElement.getText().replaceAll("\\(.*?\\)", "").replaceAll("[^0-9]", "").trim());
+            log.info("관람 연령: {}", age);
+
+            // 뮤지컬 시간 가져오기
+            WebElement showTimeElement = driver.findElement(By.xpath("//ul[@class='contentDetailList']/div"));
+            String showTime = showTimeElement.getText();
+            log.info("뮤지컬 시간: {}", showTime);
+            List<String> showTimes = parsingShowTime.parseShowTimes(showTime);
+            showTimes.forEach(show -> log.info("공연 시간: {}", show));
+
+            WebElement moreButton = driver.findElement(By.xpath("//a[@class='contentToggleBtn' and @aria-label='여닫기']"));
+            JavascriptExecutor jsExecutor = (JavascriptExecutor) driver;
+            jsExecutor.executeScript("arguments[0].click();", moreButton);
+
+            // 뮤지컬 캐스팅정보, 배우 정보 가져오기
+            List<WebElement> castingItems = driver.findElements(By.xpath("//ul[@class='castingList']/li[@class='castingItem']"));
+
+            for (WebElement item : castingItems) {
+                String actorName = item.findElement(By.xpath(".//div[@class='castingInfo']/div[@class='castingName']")).getText();
+                log.info("배우 이름: {}", actorName);
+
+                String roleName = item.findElement(By.xpath(".//div[@class='castingInfo']/div[@class='castingActor']")).getText();
+                log.info("역할 이름: {}", roleName);
+
+                String actorPhotoUrl = item.findElement(By.xpath(".//div[@class='castingTop']//img[@class='castingImage']")).getAttribute("src");
+                log.info("배우 사진 URL: {}", actorPhotoUrl);
+
+                log.info("-----------");
+            }
+        } catch (Exception e) {
+            log.error("Error fetching details for GroupId {}: {}", groupId, e.getMessage());
+        } finally {
+            // 드라이버 종료
+            seleniumConfig.quitDriver();
+        }
+    }
+
+    /**
+     * 날짜 문자열을 파싱하여 LocalDateTime 객체로 변환하는 메서드
+     * @param dateStr
+     * @return
+     */
+    private LocalDateTime parseDate(String dateStr) {
+        DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        LocalDate date = LocalDate.parse(dateStr, dateFormatter);
+        return date.atStartOfDay();
+    }
+}

--- a/src/main/java/encore/server/domain/musical/service/MusicalInfoService.java
+++ b/src/main/java/encore/server/domain/musical/service/MusicalInfoService.java
@@ -1,6 +1,10 @@
 package encore.server.domain.musical.service;
 
-import encore.server.global.common.ParsingShowTime;
+import encore.server.domain.musical.entity.Musical;
+import encore.server.domain.musical.entity.MusicalActor;
+import encore.server.domain.musical.repository.MusicalRepository;
+import encore.server.domain.ticket.entity.Actor;
+import encore.server.domain.ticket.repository.ActorRepository;
 import encore.server.global.config.SeleniumConfig;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,19 +27,39 @@ import java.util.*;
 
 @Slf4j
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class MusicalInfoService {
     private final SeleniumConfig seleniumConfig;
-    private final ParsingShowTime parsingShowTime;
+    private final MusicalRepository musicalRepository;
+    private final ActorRepository actorRepository;
 
     @Value("${jsoup.goods.url}")
     private String goodsUrl;
+
+    @Value("${selenium.title-css-selector}")
+    private String titleCssSelector;
+
+    @Value("${selenium.img-css-selector}")
+    private String imgCssSelector;
+
+    @Value("${selenium.location-xpath}")
+    private String locationXpath;
+
+    @Value("${selenium.period-xpath}")
+    private String periodXpath;
+
+    @Value("${selenium.runningtime-xpath}")
+    private String runningTimeXpath;
+
+    @Value("${selenium.age-xpath}")
+    private String ageXpath;
 
     /**
      * 뮤지컬 상세 정보를 가져오는 메서드
      * @param groupId
      */
+    @Transactional
     public void fetchMusicalDetails(String groupId) {
         String url = goodsUrl + groupId;
         WebDriver driver = new ChromeDriver();
@@ -43,53 +67,77 @@ public class MusicalInfoService {
 
         try {
             // 페이지로 이동
-            log.info("Navigating to the URL...");
             driver.get(url);
 
             // 페이지가 완전히 로드될 때까지 대기
-            log.info("Waiting for the page to load...");
-            wait.until(ExpectedConditions.presenceOfElementLocated(By.cssSelector("h2.prdTitle")));
+            wait.until(ExpectedConditions.presenceOfElementLocated(By.cssSelector(titleCssSelector)));
 
             // 뮤지컬 제목 가져오기
-            WebElement titleElement = driver.findElement(By.cssSelector("h2.prdTitle"));
-            String title = titleElement.getText();
-            log.info("뮤지컬 제목: {}", title);
+            WebElement titleElement = driver.findElement(By.cssSelector(titleCssSelector));
+            String title = titleElement.getText().replace("뮤지컬", "").trim();
 
             // 뮤지컬 이미지 URL 가져오기
-            WebElement imgElement = driver.findElement(By.cssSelector("div.posterBoxTop img.posterBoxImage"));
+            WebElement imgElement = driver.findElement(By.cssSelector(imgCssSelector));
             String imageUrl = imgElement != null ? imgElement.getAttribute("src") : null;
-            log.info("뮤지컬 이미지 URL: {}", imageUrl);
 
             // 장소 가져오기
-            WebElement locationElement = driver.findElement(By.xpath("//li[contains(@class, 'infoItem')]//strong[contains(text(), '장소')]/following-sibling::div//a"));
+            WebElement locationElement = driver.findElement(By.xpath(locationXpath));
             String location = locationElement.getText().replaceAll("\\(.*?\\)", "").trim();
-            log.info("장소: {}", location);
 
             // 공연 기간 가져오기
-            WebElement periodElement = driver.findElement(By.xpath("//li[contains(@class, 'infoItem')]//strong[contains(text(), '공연기간')]/following-sibling::div//p[@class='infoText']"));
+            WebElement periodElement = driver.findElement(By.xpath(periodXpath));
             String performancePeriod = periodElement.getText();
             String[] periodSplit = performancePeriod.split("~");
             String startDate = periodSplit[0].trim();
             String endDate = periodSplit[1].trim();
-            log.info("공연 시작일: {}", parseDate(startDate));
-            log.info("공연 종료일: {}", parseDate(endDate));
 
             // 공연 시간 가져오기
-            WebElement runningTimeElement = driver.findElement(By.xpath("//li[contains(@class, 'infoItem')]//strong[contains(text(), '공연시간')]/following-sibling::div//p[@class='infoText']"));
+            WebElement runningTimeElement = driver.findElement(By.xpath(runningTimeXpath));
             Long runningTime = Long.parseLong(runningTimeElement.getText().replaceAll("\\(.*?\\)", "").replace("분", "").trim());
-            log.info("공연 시간 (분): {}", runningTime);
 
             // 관람 연령 가져오기
-            WebElement ageElement = driver.findElement(By.xpath("//li[contains(@class, 'infoItem')]//strong[contains(text(), '관람연령')]/following-sibling::div//p[@class='infoText']"));
-            Long age = Long.parseLong(ageElement.getText().replaceAll("\\(.*?\\)", "").replaceAll("[^0-9]", "").trim());
-            log.info("관람 연령: {}", age);
+            WebElement ageElement = driver.findElement(By.xpath(ageXpath));
+            String age = ageElement.getText();
 
+            Musical musical = Musical.builder()
+                    .interparkId(groupId)
+                    .title(title)
+                    .imageUrl(imageUrl)
+                    .location(location)
+                    .startDate(parseDate(startDate))
+                    .endDate(parseDate(endDate))
+                    .runningTime(runningTime)
+                    .age(age)
+                    .musicalActors(new ArrayList<>())
+                    .showTimes(new ArrayList<>())
+                    .build();
+
+            musicalRepository.save(musical);
+
+            /*
             // 뮤지컬 시간 가져오기
             WebElement showTimeElement = driver.findElement(By.xpath("//ul[@class='contentDetailList']/div"));
             String showTime = showTimeElement.getText();
-            log.info("뮤지컬 시간: {}", showTime);
             List<String> showTimes = parsingShowTime.parseShowTimes(showTime);
-            showTimes.forEach(show -> log.info("공연 시간: {}", show));
+            Set<String> existingShowTimes = new HashSet<>();
+
+            showTimes.forEach(show -> {
+                String day = show.split(" ")[0];
+                String time = show.split(" ")[1];
+                String uniqueKey = day + " " + time;
+
+                if (!existingShowTimes.contains(uniqueKey)) {
+                    ShowTime st = ShowTime.builder()
+                            .musical(musical)
+                            .day(day)
+                            .time(time)
+                            .build();
+
+                    musical.addShowTime(st);
+                    existingShowTimes.add(uniqueKey); // 중복 방지용 키 추가
+                }
+            });
+             */
 
             WebElement moreButton = driver.findElement(By.xpath("//a[@class='contentToggleBtn' and @aria-label='여닫기']"));
             JavascriptExecutor jsExecutor = (JavascriptExecutor) driver;
@@ -100,18 +148,32 @@ public class MusicalInfoService {
 
             for (WebElement item : castingItems) {
                 String actorName = item.findElement(By.xpath(".//div[@class='castingInfo']/div[@class='castingName']")).getText();
-                log.info("배우 이름: {}", actorName);
 
                 String roleName = item.findElement(By.xpath(".//div[@class='castingInfo']/div[@class='castingActor']")).getText();
-                log.info("역할 이름: {}", roleName);
 
                 String actorPhotoUrl = item.findElement(By.xpath(".//div[@class='castingTop']//img[@class='castingImage']")).getAttribute("src");
-                log.info("배우 사진 URL: {}", actorPhotoUrl);
 
-                log.info("-----------");
+                Actor actor = Actor.builder()
+                        .name(actorName)
+                        .actorImageUrl(actorPhotoUrl)
+                        .musicalActors(new ArrayList<>())
+                        .build();
+
+                actorRepository.save(actor);
+
+                MusicalActor musicalActor = MusicalActor.builder()
+                        .actor(actor)
+                        .roleName(roleName)
+                        .isMainActor(true)
+                        .musical(musical)
+                        .build();
+
+                musical.addMusicalActors(musicalActor);
             }
+
         } catch (Exception e) {
             log.error("Error fetching details for GroupId {}: {}", groupId, e.getMessage());
+            throw e;
         } finally {
             // 드라이버 종료
             seleniumConfig.quitDriver();

--- a/src/main/java/encore/server/domain/musical/service/MusicalListService.java
+++ b/src/main/java/encore/server/domain/musical/service/MusicalListService.java
@@ -1,4 +1,4 @@
-package encore.server.global.util.jsoup;
+package encore.server.domain.musical.service;
 
 import encore.server.domain.musical.repository.MusicalRepository;
 import encore.server.global.config.JsoupConfig;
@@ -17,18 +17,19 @@ import java.util.List;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class GetMusicals {
+public class MusicalListService {
     private final MusicalRepository musicalRepository;
     private final JsoupConfig jsoupConfig;
+    private final MusicalInfoService musicalInfoService;
 
     @Value("${jsoup.goods.list-url}")
     private String url;
 
     /**
-     * Interpark 뮤지컬 페이지에서 뮤지컬 ID(GroupCode)를 추출하는 메서드
+     * Interpark 뮤지컬 페이지에서 뮤지컬 ID(GroupCode)를 추출하여 저장하는 메서드
      * @return List<String> musicalIds (저장할 뮤지컬 ID 목록)
      */
-    public List<String> getMusicalIds() {
+    public List<String> crawlingMusicalInfo() {
         List<String> musicalIds = new ArrayList<>();
         try {
             // 1. Jsoup 연결 및 Document 가져오기
@@ -50,6 +51,7 @@ public class GetMusicals {
                     if (groupId != null) {
                         musicalIds.add(groupId);
                         log.info("GroupCode: " + groupId);
+                        musicalInfoService.fetchMusicalDetails(groupId); // 뮤지컬 상세 정보 가져오기
                     }
                 }
             }

--- a/src/main/java/encore/server/domain/ticket/entity/Actor.java
+++ b/src/main/java/encore/server/domain/ticket/entity/Actor.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
-@Builder
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -31,9 +30,8 @@ public class Actor extends BaseTimeEntity {
     @OneToMany(mappedBy = "actor", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MusicalActor> musicalActors = new ArrayList<>();
 
-
-    public Actor(Long id, String name, String actorImageUrl, List<MusicalActor> musicalActors) {
-        this.id = id;
+    @Builder
+    public Actor(String name, String actorImageUrl, List<MusicalActor> musicalActors) {
         this.name = name;
         this.actorImageUrl = actorImageUrl;
         this.musicalActors = musicalActors != null ? musicalActors : new ArrayList<>();

--- a/src/main/java/encore/server/domain/ticket/service/TicketService.java
+++ b/src/main/java/encore/server/domain/ticket/service/TicketService.java
@@ -55,7 +55,6 @@ public class TicketService {
         //actordto->actor
         List<Actor> actors = request.actors().stream()
                 .map(actorDTO -> Actor.builder()
-                        .id(actorDTO.id())
                         .name(actorDTO.name())
                         .actorImageUrl(actorDTO.actorImageUrl())
                         .build())
@@ -142,7 +141,6 @@ public class TicketService {
         if (request.actors() != null) {
             List<Actor> actors = request.actors().stream()
                     .map(actorDTO -> Actor.builder()
-                            .id(actorDTO.id())
                             .name(actorDTO.name())
                             .actorImageUrl(actorDTO.actorImageUrl())
                             .build())

--- a/src/main/java/encore/server/global/common/ParsingShowTime.java
+++ b/src/main/java/encore/server/global/common/ParsingShowTime.java
@@ -1,0 +1,84 @@
+package encore.server.global.common;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@Component
+public class ParsingShowTime {
+    /**
+     * 요일을 영어로 변환하는 맵
+     */
+    private static Map<String, String> dayMap = new HashMap<>();
+
+    static {
+        dayMap.put("월", "MON");
+        dayMap.put("화", "TUE");
+        dayMap.put("수", "WED");
+        dayMap.put("목", "THU");
+        dayMap.put("금", "FRI");
+        dayMap.put("토", "SAT");
+        dayMap.put("일", "SUN");
+    }
+
+    /**
+     * 공연 시간을 파싱하는 메서드
+     * @param showTime
+     * @return List<String> 공연 시간 목록
+     */
+    public List<String> parseShowTimes(String showTime) {
+        List<String> result = new ArrayList<>();
+
+        // 월, 화, 수, 목, 금, 토, 일 순서대로 반복문을 돌며 처리
+        String[] daysOfWeek = {"월", "화", "수", "목", "금", "토", "일"};
+
+        for (String d : daysOfWeek) {
+            // 해당 요일에 맞는 시간 패턴을 찾아서 추출
+            String pattern = d + "(?!,\\s*공휴일)\\s*[^0-9]*(\\d+시(,\\s*\\d+시)*)?";
+            Matcher matcher = Pattern.compile(pattern).matcher(showTime);
+            // 공연 시간이 있는 요일 및 시간 처리
+            while (matcher.find()) {
+                String times = matcher.group(1); // 시간 정보
+
+                // 공연 시간이 있는 요일에 대해서만 처리
+                if (times != null && !times.contains("공연없음")) {
+                    // 쉼표로 구분된 시간 처리
+                    String[] timeArray = times.split(",\\s*");
+
+                    // 해당 요일들에 대해 동일한 시간을 적용
+                    for (String time : timeArray) {
+                        String formattedTime = formatTime(time);
+                        result.add(dayMap.get(d) + ": " + formattedTime);
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * 시간을 24시간 형식으로 변환하는 메서드
+     * @param time
+     * @return String 24시간 형식의 시간
+     */
+    private static String formatTime(String time) {
+        // "시"를 제거하고 분리
+        String[] timeParts = time.replace("시", "").split("분");
+        String hour = timeParts[0].trim();
+        String minute = timeParts.length > 1 ? timeParts[1].trim() : "00";
+
+        int hourInt = Integer.parseInt(hour);
+
+        if (hourInt < 12) {
+            hourInt += 12;
+        }
+
+        return String.format("%02d:%s", hourInt, minute);
+    }
+}

--- a/src/main/java/encore/server/global/config/JsoupConfig.java
+++ b/src/main/java/encore/server/global/config/JsoupConfig.java
@@ -1,0 +1,13 @@
+package encore.server.global.config;
+
+import org.jsoup.Connection;
+import org.jsoup.Jsoup;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JsoupConfig {
+    // Jsoup 연결 메서드
+    public Connection jsoupConnection(String url) throws Exception {
+        return Jsoup.connect(url);
+    }
+}

--- a/src/main/java/encore/server/global/config/SeleniumConfig.java
+++ b/src/main/java/encore/server/global/config/SeleniumConfig.java
@@ -1,5 +1,6 @@
 package encore.server.global.config;
 
+import jakarta.annotation.PostConstruct;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
@@ -11,13 +12,15 @@ import org.springframework.context.annotation.Configuration;
 public class SeleniumConfig {
 
     private WebDriver driver;
+
     @Value("${selenium.chrome-driver-path}")
     private String chromeDriverPath;
 
     /**
      * Selenium WebDriver 초기화
      */
-    public SeleniumConfig() {
+    @PostConstruct
+    public void initDriver() {
         try {
             // WebDriver 설정
             System.setProperty("webdriver.chrome.driver", chromeDriverPath);
@@ -25,7 +28,7 @@ public class SeleniumConfig {
             options.addArguments("--headless"); // 브라우저 창 없이 실행
             options.addArguments("--disable-gpu");
             options.addArguments("--no-sandbox");
-            options.addArguments("--disable-popup-blocking");       //팝업안띄움
+            options.addArguments("--disable-popup-blocking"); // 팝업 안 띄움
 
             this.driver = new ChromeDriver(options);
         } catch (Exception e) {
@@ -37,7 +40,9 @@ public class SeleniumConfig {
 
     @Bean
     public WebDriver getDriver() {
-        System.setProperty("webdriver.chrome.driver", chromeDriverPath);
+        if (driver == null) {
+            throw new IllegalStateException("WebDriver is not initialized. Please check the Selenium configuration.");
+        }
         return driver;
     }
 

--- a/src/main/java/encore/server/global/config/SeleniumConfig.java
+++ b/src/main/java/encore/server/global/config/SeleniumConfig.java
@@ -1,0 +1,49 @@
+package encore.server.global.config;
+
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SeleniumConfig {
+
+    private WebDriver driver;
+    @Value("${selenium.chrome-driver-path}")
+    private String chromeDriverPath;
+
+    /**
+     * Selenium WebDriver 초기화
+     */
+    public SeleniumConfig() {
+        try {
+            // WebDriver 설정
+            System.setProperty("webdriver.chrome.driver", chromeDriverPath);
+            ChromeOptions options = new ChromeOptions();
+            options.addArguments("--headless"); // 브라우저 창 없이 실행
+            options.addArguments("--disable-gpu");
+            options.addArguments("--no-sandbox");
+            options.addArguments("--disable-popup-blocking");       //팝업안띄움
+
+            this.driver = new ChromeDriver(options);
+        } catch (Exception e) {
+            // 예외 처리
+            System.err.println("Error initializing Selenium WebDriver: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    @Bean
+    public WebDriver getDriver() {
+        System.setProperty("webdriver.chrome.driver", chromeDriverPath);
+        return driver;
+    }
+
+    public void quitDriver() {
+        if (driver != null) {
+            driver.quit();
+        }
+    }
+}

--- a/src/main/java/encore/server/global/util/jsoup/GetMusicals.java
+++ b/src/main/java/encore/server/global/util/jsoup/GetMusicals.java
@@ -1,0 +1,76 @@
+package encore.server.global.util.jsoup;
+
+import encore.server.domain.musical.repository.MusicalRepository;
+import encore.server.global.config.JsoupConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Connection;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GetMusicals {
+    private final MusicalRepository musicalRepository;
+    private final JsoupConfig jsoupConfig;
+
+    @Value("${jsoup.goods.list-url}")
+    private String url;
+
+    /**
+     * Interpark 뮤지컬 페이지에서 뮤지컬 ID(GroupCode)를 추출하는 메서드
+     * @return List<String> musicalIds (저장할 뮤지컬 ID 목록)
+     */
+    public List<String> getMusicalIds() {
+        List<String> musicalIds = new ArrayList<>();
+        try {
+            // 1. Jsoup 연결 및 Document 가져오기
+            Connection connection = jsoupConfig.jsoupConnection(url);
+            Document document = connection.get();
+
+            // 2. 뮤지컬 리스트에서 각 ID(GroupCode) 추출
+            Elements rows = document.select("tbody > tr");
+
+            // 3. 각 행에서 GroupCode 추출
+            for (Element row : rows) {
+                Element linkElement = row.selectFirst("a[href*='GoodsInfo.asp?GroupCode=']");
+                if (linkElement != null) { // GroupCode가 포함된 링크가 존재하는 경우
+                    String href = linkElement.attr("href");
+                    String groupId = extractGroupId(href); // GroupCode 추출
+                    if(musicalRepository.existsByInterparkId(groupId)) { // 이미 저장했던 뮤지컬인 경우 패스
+                        continue;
+                    }
+                    if (groupId != null) {
+                        musicalIds.add(groupId);
+                        log.info("GroupCode: " + groupId);
+                    }
+                }
+            }
+            log.info(("총 " + musicalIds.size() + "개의 뮤지컬 ID 추출 완료"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return musicalIds;
+    }
+
+    /**
+     * href에서 GroupCode 추출하는 메서드
+     * @param href
+     * @return GroupCode
+     */
+    private String extractGroupId(String href) {
+        String prefix = "GroupCode=";
+        int startIndex = href.indexOf(prefix);
+        if (startIndex != -1) {
+            return href.substring(startIndex + prefix.length());
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- #93 

## 📝작업 내용
- 뮤지컬 리스트는 Jsoup으로 크롤링하여 뮤지컬 id 리스트를 가져왔습니다.
- 뮤지컬 id 리스트를 가져올 때, 이미 앙코르 디비에 저장되어있던 뮤지컬 id는 제외하고 불러옵니다.
- 크롤링해온 id 리스트의 각 뮤지컬 정보는 동적 컨텐츠가 있어 Selenium으로 크롤링해왔습니다. (Jsoup이 크롤링 속도가 훨씬 빠르기 때문에 라이브러리를 통일하지 않고 Jsoup으로 가져올 수 있는 뮤지컬 리스트는 그대로 Jsoup으로 적용했습니다.)

### 추후에 할일
- 뮤지컬 일정은 뮤지컬 id마다 형식이 너무 달라서 우선 주석처리해두었습니다. 이부분에 대해서는 기획자분과 상의한 결과 티켓북에서 사용자가 직접 입력하는 방식을 택할 것 같습니다.
- 지금은 배포 환경에서 크롤링 테스트를 위해 api로 만들어두었는데, 배포 환경에서 제대로 작동이 되는 것이 확인이 되면 스케줄링으로 매일 정각에 크롤링해오는 방식으로 변경할 예정입니다.
