### PR TITLE
#98 Fix: 티켓북 생성시 배우 id만 요청하도록 변경, 배우생성 API 추가

### DIFF
--- a/src/main/java/encore/server/domain/ticket/controller/TicketController.java
+++ b/src/main/java/encore/server/domain/ticket/controller/TicketController.java
@@ -2,6 +2,8 @@ package encore.server.domain.ticket.controller;
 
 
 
+import encore.server.domain.ticket.converter.TicketConverter;
+import encore.server.domain.ticket.dto.request.ActorCreateReq;
 import encore.server.domain.ticket.dto.request.ActorDTO;
 import encore.server.domain.ticket.dto.request.TicketCreateReq;
 import encore.server.domain.ticket.dto.request.TicketUpdateReq;
@@ -9,6 +11,7 @@ import encore.server.domain.ticket.dto.response.TicketCreateRes;
 import encore.server.domain.ticket.dto.response.TicketRes;
 import encore.server.domain.ticket.dto.response.TicketSimpleRes;
 import encore.server.domain.ticket.dto.response.TicketUpdateRes;
+import encore.server.domain.ticket.entity.Actor;
 import encore.server.domain.ticket.service.TicketService;
 import encore.server.global.common.ApplicationResponse;
 import encore.server.global.exception.ErrorCode;
@@ -43,6 +46,14 @@ public class TicketController {
         List<ActorDTO> responses = ticketService.searchActorsByName(keyword);
         return ApplicationResponse.ok(responses);
     }
+
+    @Operation(summary = "배우 추가", description = "새로운 배우를 추가합니다.")
+    @PostMapping("/actors")
+    public ApplicationResponse<ActorDTO> addActor(@RequestBody ActorCreateReq actorCreateReq) {
+        Actor actor = ticketService.createNewActor(actorCreateReq);  // 배우 생성
+        return ApplicationResponse.ok(TicketConverter.toActorDTO(actor));
+    }
+
 
     @Operation(summary = "티켓북 리스트 조회", description = "기간별 티켓북 리스트를 조회합니다.")
     @GetMapping("/list")

--- a/src/main/java/encore/server/domain/ticket/converter/TicketConverter.java
+++ b/src/main/java/encore/server/domain/ticket/converter/TicketConverter.java
@@ -32,11 +32,7 @@ public class TicketConverter {
                 .showTime(ticket.getShowTime())
                 .seat(ticket.getSeat())
                 .actors(ticket.getActors().stream()
-                        .map(actor -> ActorDTO.builder()
-                                .id(actor.getId())
-                                .name(actor.getName())
-                                .actorImageUrl(actor.getActorImageUrl())
-                                .build())
+                        .map(TicketConverter::toActorDTO)  // ActorDTO로 변환
                         .collect(Collectors.toList()))
                 .ticketImageUrl(ticket.getTicketImageUrl())
                 .build();

--- a/src/main/java/encore/server/domain/ticket/dto/request/ActorCreateReq.java
+++ b/src/main/java/encore/server/domain/ticket/dto/request/ActorCreateReq.java
@@ -1,0 +1,13 @@
+package encore.server.domain.ticket.dto.request;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record ActorCreateReq(
+        String name,
+        String actorImageUrl  //null 가능
+) {
+}

--- a/src/main/java/encore/server/domain/ticket/dto/request/TicketCreateReq.java
+++ b/src/main/java/encore/server/domain/ticket/dto/request/TicketCreateReq.java
@@ -15,7 +15,7 @@ public record TicketCreateReq(
         LocalDate viewedDate,
         String showTime,
         String seat,
-        List<ActorDTO> actors, // Actor 리스트
+        List<Long> actorIds, // Actor 리스트
         String ticketImageUrl
 ) {
 }

--- a/src/main/java/encore/server/domain/ticket/repository/ActorRepository.java
+++ b/src/main/java/encore/server/domain/ticket/repository/ActorRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface ActorRepository extends JpaRepository<Actor, Long> {
     List<Actor> findByNameContaining(String keyword);
     Optional<Actor> findByActorImageUrl(String actorImageUrl);
+    List<Actor> findAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/encore/server/domain/ticket/service/TicketService.java
+++ b/src/main/java/encore/server/domain/ticket/service/TicketService.java
@@ -49,15 +49,15 @@ public class TicketService {
 
         //validation
         Musical musical = musicalRepository.findById(request.musicalId())
-                .orElseThrow(() -> new RuntimeException("Musical not found"));
+                .orElseThrow(() -> new ApplicationException(ErrorCode.MUSICAL_NOT_FOUND_EXCEPTION));
 
         User user = userRepository.findById(request.userId())
-                .orElseThrow(() -> new RuntimeException("User not found"));
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND_EXCEPTION));
 
         // actorIds로 배우를 조회하여 리스트로 반환
         List<Actor> actors = actorRepository.findAllByIdIn(request.actorIds());
         if (actors.size() != request.actorIds().size()) {
-            throw new RuntimeException("Some actors not found");
+            throw new ApplicationException(ErrorCode.ACTOR_NOT_FOUND_EXCEPTION);
         }
 
         //business logic
@@ -95,7 +95,7 @@ public class TicketService {
 
         Actor actor = Actor.builder()
                 .name(actorCreateReq.name())
-                .actorImageUrl(actorImageUrl)  // null도 허용
+                .actorImageUrl(actorCreateReq.actorImageUrl())  // null도 허용
                 .build();
 
         return actorRepository.save(actor);

--- a/src/main/java/encore/server/domain/ticket/service/TicketService.java
+++ b/src/main/java/encore/server/domain/ticket/service/TicketService.java
@@ -6,6 +6,7 @@ import encore.server.domain.musical.repository.MusicalRepository;
 import encore.server.domain.review.entity.Review;
 import encore.server.domain.review.repository.ReviewRepository;
 import encore.server.domain.ticket.converter.TicketConverter;
+import encore.server.domain.ticket.dto.request.ActorCreateReq;
 import encore.server.domain.ticket.dto.request.ActorDTO;
 import encore.server.domain.ticket.dto.request.TicketCreateReq;
 import encore.server.domain.ticket.dto.request.TicketUpdateReq;
@@ -53,13 +54,11 @@ public class TicketService {
         User user = userRepository.findById(request.userId())
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
-        //actordto->actor
-        List<Actor> actors = request.actors().stream()
-                .map(actorDTO -> Actor.builder()
-                        .name(actorDTO.name())
-                        .actorImageUrl(actorDTO.actorImageUrl())
-                        .build())
-                .collect(Collectors.toList());
+        // actorIds로 배우를 조회하여 리스트로 반환
+        List<Actor> actors = actorRepository.findAllByIdIn(request.actorIds());
+        if (actors.size() != request.actorIds().size()) {
+            throw new RuntimeException("Some actors not found");
+        }
 
         //business logic
         //create ticket
@@ -86,6 +85,20 @@ public class TicketService {
         return actors.stream()
                 .map(TicketConverter::toActorDTO) // Converter를 이용해 변환
                 .toList();
+    }
+
+    // 새로운 배우 추가
+    @Transactional
+    public Actor createNewActor(ActorCreateReq actorCreateReq) {
+        // actorImageUrl이 null일 경우 그냥 null로 설정
+        String actorImageUrl = actorCreateReq.actorImageUrl();
+
+        Actor actor = Actor.builder()
+                .name(actorCreateReq.name())
+                .actorImageUrl(actorImageUrl)  // null도 허용
+                .build();
+
+        return actorRepository.save(actor);
     }
 
     //티켓북 조회


### PR DESCRIPTION
## #️⃣연관된 이슈
> #98 

## 📝작업 내용
> 티켓북 생성시 배우 id만 요청하도록 변경
> 배우 생성 API 추가 -> 티켓북 생성할 때 배우 검색시 없으면 사용자가 생성할 수 있도록 추가 

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> showtime을 티켓북 생성시 입력하는 showtime으로 생성되도록 구현이 이미 되어있어서 따로 변경하지 않아도 될것 같습니다.
뮤지컬 생성시, showtime을 등록할 수 있는데 현재는 null 값으로 입력받고 추후에 사용하게 되면 써도 될 것 같아 남겨놓겠습니다!
> 