### PR TITLE
Fix: 티켓북 관련 오류 수정, 상세조회, 리뷰없는 티켓북 조회 api추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ out/
 ### application.yml ###
 !**/src/main/resources/application.yml
 /src/main/resources/application.yml
+
+
+/src/main/resources/*.json

--- a/src/main/java/encore/server/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/encore/server/domain/review/repository/ReviewRepository.java
@@ -13,6 +13,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRep
     Optional<Review> findByIdAndDeletedAtIsNull(Long reviewId);
     List<Review> findByUserIdAndDeletedAtIsNull(Long userId);
 
+    Optional<Review> findByTicketIdAndUserIdAndDeletedAtIsNull(Long ticketId, Long userId);
     @Query("SELECT r FROM Review r " +
             "JOIN FETCH r.user u " +
             "JOIN FETCH r.ticket t " +

--- a/src/main/java/encore/server/domain/ticket/controller/TicketController.java
+++ b/src/main/java/encore/server/domain/ticket/controller/TicketController.java
@@ -11,6 +11,7 @@ import encore.server.domain.ticket.dto.response.TicketCreateRes;
 import encore.server.domain.ticket.dto.response.TicketRes;
 import encore.server.domain.ticket.dto.response.TicketSimpleRes;
 import encore.server.domain.ticket.dto.response.TicketUpdateRes;
+import encore.server.domain.ticket.dto.response.TicketDetailRes;
 import encore.server.domain.ticket.entity.Actor;
 import encore.server.domain.ticket.service.TicketService;
 import encore.server.global.common.ApplicationResponse;
@@ -62,6 +63,15 @@ public class TicketController {
         List<TicketRes> ticketList = ticketService.getTicketList(userId, dateRange);
         return ApplicationResponse.ok(ticketList);
     }
+
+    @Operation(summary = "티켓북 상세 조회", description = "티켓북의 상세 정보를 조회합니다.")
+    @GetMapping("/{ticketId}")
+    public ApplicationResponse<TicketDetailRes> getTicketDetail(@PathVariable Long ticketId) {
+        Long userId = getUserId(); // 현재는 mock
+        TicketDetailRes detail = ticketService.getTicketDetail(ticketId, userId);
+        return ApplicationResponse.ok(detail);
+    }
+
 
     @Operation(summary = "티켓북 수정", description = "티켓북을 수정합니다.")
     @PatchMapping("/{ticketId}")

--- a/src/main/java/encore/server/domain/ticket/controller/TicketController.java
+++ b/src/main/java/encore/server/domain/ticket/controller/TicketController.java
@@ -100,6 +100,15 @@ public class TicketController {
         return ApplicationResponse.ok(ticketList);
     }
 
+    @Operation(summary = "리뷰 작성되지 않은 티켓북 리스트 조회", description = "리뷰가 작성되지 않은 티켓북 목록을 조회합니다.")
+    @GetMapping("/unreviewed")
+    public ApplicationResponse<List<TicketRes>> getUnreviewedTicketList() {
+        Long userId = getUserId(); // mock
+        List<TicketRes> tickets = ticketService.getUnreviewedTicketList(userId);
+        return ApplicationResponse.ok(tickets);
+    }
+
+
 
 
     private Long getUserId() {

--- a/src/main/java/encore/server/domain/ticket/converter/TicketConverter.java
+++ b/src/main/java/encore/server/domain/ticket/converter/TicketConverter.java
@@ -28,6 +28,7 @@ public class TicketConverter {
                 .id(ticket.getId())
                 .userId(ticket.getUser().getId())
                 .musicalId(ticket.getMusical().getId())
+                .title(ticket.getTitle())
                 .viewedDate(ticket.getViewedDate())
                 .showTime(ticket.getShowTime())
                 .seat(ticket.getSeat())
@@ -77,6 +78,7 @@ public class TicketConverter {
                 .hasReview(reviewOpt.isPresent())
                 .totalRating(reviewOpt.map(r -> r.getReviewData().getRating().getTotalRating()).orElse(null))
                 .ticketImageUrl(ticket.getTicketImageUrl())
+                .musicalImageUrl(ticket.getMusical().getImageUrl())
                 .build();
     }
 

--- a/src/main/java/encore/server/domain/ticket/dto/response/TicketCreateRes.java
+++ b/src/main/java/encore/server/domain/ticket/dto/response/TicketCreateRes.java
@@ -16,6 +16,7 @@ public record TicketCreateRes(
         Long id,
         Long userId,
         Long musicalId,
+        String title,
         LocalDate viewedDate,
         String showTime,
         String seat,

--- a/src/main/java/encore/server/domain/ticket/dto/response/TicketDetailRes.java
+++ b/src/main/java/encore/server/domain/ticket/dto/response/TicketDetailRes.java
@@ -1,0 +1,37 @@
+package encore.server.domain.ticket.dto.response;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import encore.server.domain.ticket.dto.request.ActorDTO;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public record TicketDetailRes(
+        Long ticketId,
+        String ticketTitle,
+        String seat,
+        String showTime,
+        String ticketImageUrl,
+        LocalDate viewedDate,
+        boolean hasReview,
+        Long reviewId,
+
+        // 뮤지컬 정보
+        Long musicalId,
+        String musicalTitle,
+        String location,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        Long runningTime,
+        String age,
+        String imageUrl,
+        Long series,
+
+        // 배우 목록
+        List<ActorDTO> actors
+) {}

--- a/src/main/java/encore/server/domain/ticket/dto/response/TicketRes.java
+++ b/src/main/java/encore/server/domain/ticket/dto/response/TicketRes.java
@@ -22,6 +22,7 @@ public record TicketRes(
         List<String> actors,
         Boolean hasReview,
         Float totalRating,
-        String ticketImageUrl
+        String ticketImageUrl,
+        String musicalImageUrl
 ) {
 }

--- a/src/main/java/encore/server/domain/ticket/service/TicketService.java
+++ b/src/main/java/encore/server/domain/ticket/service/TicketService.java
@@ -228,5 +228,23 @@ public class TicketService {
                 .collect(Collectors.toList());
     }
 
+    //리뷰 작성하지 않은 티켓북만 조회
+    public List<TicketRes> getUnreviewedTicketList(Long userId) {
+        // validation
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND_EXCEPTION));
+
+        //business login
+        // 전체 티켓 조회
+        List<Ticket> tickets = ticketRepository.findByUserIdAndDeletedAtIsNull(userId);
+
+        // 리뷰 없는 티켓만 필터링
+        return tickets.stream()
+                .filter(ticket -> reviewRepository.findByTicketIdAndDeletedAtIsNull(ticket.getId()).isEmpty())
+                .map(ticket -> TicketConverter.toTicketRes(ticket, Optional.empty()))
+                .collect(Collectors.toList());
+    }
+
+
 
 }

--- a/src/main/java/encore/server/domain/ticket/service/TicketService.java
+++ b/src/main/java/encore/server/domain/ticket/service/TicketService.java
@@ -65,6 +65,7 @@ public class TicketService {
         Ticket ticket = Ticket.builder()
                 .user(user)
                 .musical(musical)
+                .title(musical.getTitle())
                 .viewedDate(request.viewedDate())
                 .showTime(request.showTime())
                 .seat(request.seat())


### PR DESCRIPTION
## #️⃣연관된 이슈
> #114

## 📝작업 내용
> 1. 티켓북 상세 조회API 추가
  - 현재 티켓북 상세페이지가 없는 것 같아 새로 추가하였습니다. 리뷰 작성 바로가기 버튼을 위해, hasreview, reviewId를 응답에 포함하였습니다.
  - api명세서에서 "티켓북 상세 조회" 페이지를 보시면 됩니다.

> 2. 프리미엄 리뷰 작성->티켓북 선택 부분을 위한 새로운 api 추가
  - 프론트에서 요청하신 "티켓북 리스트를 조회할 때 아예 리뷰에 쓰이지 않은 항목들만 필터링되어서 불러와줄 수 있는 api"를 새로 추가하였습니다. 
  - api명세서에서 "리뷰 작성하지 않은 티켓북 리스트 조회" 페이지를 보시면 됩니다.

> 3. 티켓북 생성api 응답값에 뮤지컬 제목을 추가하였습니다.

> 4. 티켓북 생성시, ticket_title에 뮤지컬 제목이 저장되고 있지 않아 db에 저장될 수 있도록 수정하였습니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> 
