### PR TITLE
Feat: 소셜 로그인 플로우 변경 및 직접 구현으로 변경

### DIFF
--- a/src/main/java/encore/server/domain/user/controller/OAuthController.java
+++ b/src/main/java/encore/server/domain/user/controller/OAuthController.java
@@ -1,0 +1,38 @@
+package encore.server.domain.user.controller;
+
+import encore.server.domain.user.dto.response.OAuthURLRes;
+import encore.server.domain.user.enumerate.AuthProvider;
+import encore.server.domain.user.service.oauth.OAuthLoginService;
+import java.net.URI;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/v1/oauth2")
+@RequiredArgsConstructor
+public class OAuthController {
+
+  private final Map<AuthProvider, OAuthLoginService> loginServices;
+
+  @GetMapping("/{provider}/login")
+  public ResponseEntity<OAuthURLRes> getLoginUrl(@PathVariable AuthProvider provider) {
+    OAuthURLRes response = loginServices.get(provider).getLoginUrl();
+    return ResponseEntity.ok(response);
+  }
+
+  @RequestMapping(value = "/{provider}/callback", method = {RequestMethod.GET, RequestMethod.POST})
+  public ResponseEntity<Void> loginCallback(@PathVariable AuthProvider provider,
+      @RequestParam String code) {
+    String redirectUrl = loginServices.get(provider).loginWithCode(code);
+    return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(redirectUrl)).build();
+  }
+
+}

--- a/src/main/java/encore/server/domain/user/converter/OAuthProfileConverter.java
+++ b/src/main/java/encore/server/domain/user/converter/OAuthProfileConverter.java
@@ -1,0 +1,45 @@
+package encore.server.domain.user.converter;
+
+import encore.server.domain.user.dto.profile.GoogleUserProfile;
+import encore.server.domain.user.dto.request.UserLoginReq;
+import encore.server.domain.user.dto.request.UserSignupReq;
+import encore.server.domain.user.dto.profile.KakaoProfileResponse;
+import encore.server.domain.user.enumerate.AuthProvider;
+import encore.server.domain.user.enumerate.UserRole;
+
+public class OAuthProfileConverter {
+
+  public static UserLoginReq profileToLoginReq(KakaoProfileResponse profile) {
+    return UserLoginReq.builder()
+        .email(profile.getKakao_account().getEmail())
+        .password(profile.getKakao_account().getEmail())
+        .build();
+  }
+
+  public static UserLoginReq profileToLoginReq(GoogleUserProfile profile) {
+    return UserLoginReq.builder()
+        .email(profile.getEmail())
+        .password(profile.getEmail())
+        .build();
+  }
+
+  public static UserSignupReq profileToSignupReq(KakaoProfileResponse profile) {
+    return UserSignupReq.builder()
+        .email(profile.getKakao_account().getEmail())
+        .password(profile.getKakao_account().getEmail())
+        .name(profile.getKakao_account().getName())
+        .provider(AuthProvider.KAKAO)
+        .role(UserRole.BASIC)
+        .build();
+  }
+
+  public static UserSignupReq profileToSignupReq(GoogleUserProfile profile) {
+    return UserSignupReq.builder()
+        .email(profile.getEmail())
+        .password(profile.getEmail())
+        .name(profile.getName())
+        .provider(AuthProvider.GOOGLE)
+        .role(UserRole.BASIC)
+        .build();
+  }
+}

--- a/src/main/java/encore/server/domain/user/dto/profile/GoogleUserProfile.java
+++ b/src/main/java/encore/server/domain/user/dto/profile/GoogleUserProfile.java
@@ -1,0 +1,12 @@
+package encore.server.domain.user.dto.profile;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class GoogleUserProfile {
+  private String sub;
+  private String email;
+  private String name;
+}

--- a/src/main/java/encore/server/domain/user/dto/profile/KakaoProfileResponse.java
+++ b/src/main/java/encore/server/domain/user/dto/profile/KakaoProfileResponse.java
@@ -1,0 +1,20 @@
+package encore.server.domain.user.dto.profile;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class KakaoProfileResponse {
+
+  private Long id;
+  private String connected_at;
+  private KakaoAccount kakao_account;
+
+  @Data
+  @NoArgsConstructor
+  public static class KakaoAccount {
+    private String email;
+    private String name;
+  }
+}

--- a/src/main/java/encore/server/domain/user/dto/response/OAuthURLRes.java
+++ b/src/main/java/encore/server/domain/user/dto/response/OAuthURLRes.java
@@ -1,0 +1,8 @@
+package encore.server.domain.user.dto.response;
+
+
+public record OAuthURLRes(
+    String url
+) {
+
+}

--- a/src/main/java/encore/server/domain/user/service/UserAuthService.java
+++ b/src/main/java/encore/server/domain/user/service/UserAuthService.java
@@ -98,6 +98,7 @@ public class UserAuthService {
         return UserLoginRes.builder()
             .accessToken(accessToken)
             .isAgreedRequiredTerm(numOfAgreedRequiredTerm == numOfTermsByIsOptionalFalse)
+            .isActivePenalty(true)
             .userPenaltyInfo(
                 UserPenaltyInfo.builder()
                     .penaltyStatus(penaltyHistory.getStatus())
@@ -114,6 +115,7 @@ public class UserAuthService {
     return UserLoginRes.builder()
         .accessToken(accessToken)
         .isAgreedRequiredTerm(numOfAgreedRequiredTerm == numOfTermsByIsOptionalFalse)
+        .isActivePenalty(false)
         .build();
   }
 

--- a/src/main/java/encore/server/domain/user/service/oauth/GoogleOAuthService.java
+++ b/src/main/java/encore/server/domain/user/service/oauth/GoogleOAuthService.java
@@ -1,0 +1,103 @@
+package encore.server.domain.user.service.oauth;
+
+import encore.server.domain.user.converter.OAuthProfileConverter;
+import encore.server.domain.user.dto.profile.GoogleUserProfile;
+import encore.server.domain.user.dto.response.OAuthURLRes;
+import encore.server.domain.user.dto.response.UserLoginRes;
+import encore.server.domain.user.service.UserAuthService;
+import encore.server.global.config.oauth.GoogleOAuthConfig;
+import encore.server.global.exception.ApplicationException;
+import java.util.Map;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleOAuthService implements OAuthLoginService {
+
+  private final GoogleOAuthConfig config;
+  private final RestTemplate restTemplate = new RestTemplate();
+  private final UserAuthService userAuthService;
+
+  @Override
+  public OAuthURLRes getLoginUrl() {
+    String uriString = UriComponentsBuilder.fromHttpUrl(
+            "https://accounts.google.com/o/oauth2/v2/auth")
+        .queryParam("client_id", config.getClientId())
+        .queryParam("redirect_uri", config.getRedirectUri())
+        .queryParam("response_type", "code")
+        .queryParam("scope", config.getScope())
+        .queryParam("access_type", "offline")
+        .build().toUriString();
+    return new OAuthURLRes(uriString);
+  }
+
+  @Override
+  public String loginWithCode(String code) {
+    String accessToken = getAccessToken(code);
+    GoogleUserProfile userInfo = getUserInfo(accessToken);
+    UserLoginRes login;
+
+    try {
+      login = userAuthService.login(OAuthProfileConverter.profileToLoginReq(userInfo));
+    } catch (ApplicationException e) {
+      userAuthService.signup(OAuthProfileConverter.profileToSignupReq(userInfo));
+      login = userAuthService.login(OAuthProfileConverter.profileToLoginReq(userInfo));
+    }
+
+    return UriComponentsBuilder.fromHttpUrl("encore://oauth")
+        .queryParam("token", login.accessToken())
+        .queryParam("isAgreedRequiredTerm", login.isAgreedRequiredTerm())
+        .queryParam("isActivePenalty", login.isActivePenalty())
+        .build().toUriString();
+  }
+
+  private String getAccessToken(String code) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+    MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+    body.add("code", code);
+    body.add("client_id", config.getClientId());
+    body.add("client_secret", config.getClientSecret());
+    body.add("redirect_uri", config.getRedirectUri());
+    body.add("grant_type", "authorization_code");
+
+    HttpEntity<?> request = new HttpEntity<>(body, headers);
+
+    ResponseEntity<Map> response = restTemplate.postForEntity(
+        "https://oauth2.googleapis.com/token", request, Map.class
+    );
+
+    if (!response.getStatusCode().is2xxSuccessful()) {
+      throw new RuntimeException("구글 access token 요청 실패");
+    }
+
+    return (String) Objects.requireNonNull(response.getBody()).get("access_token");
+  }
+
+  private GoogleUserProfile getUserInfo(String accessToken) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setBearerAuth(accessToken);
+
+    HttpEntity<?> request = new HttpEntity<>(headers);
+    ResponseEntity<GoogleUserProfile> response = restTemplate.exchange(
+        "https://www.googleapis.com/oauth2/v3/userinfo",
+        HttpMethod.GET,
+        request,
+        GoogleUserProfile.class
+    );
+
+    return response.getBody();
+  }
+}

--- a/src/main/java/encore/server/domain/user/service/oauth/KakaoOAuthService.java
+++ b/src/main/java/encore/server/domain/user/service/oauth/KakaoOAuthService.java
@@ -1,0 +1,99 @@
+package encore.server.domain.user.service.oauth;
+
+import encore.server.domain.user.converter.OAuthProfileConverter;
+import encore.server.domain.user.dto.profile.KakaoProfileResponse;
+import encore.server.domain.user.dto.response.OAuthURLRes;
+import encore.server.domain.user.dto.response.UserLoginRes;
+import encore.server.domain.user.service.UserAuthService;
+import encore.server.global.config.oauth.KakaoOAuthConfig;
+import encore.server.global.exception.ApplicationException;
+import java.util.Map;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOAuthService implements OAuthLoginService {
+
+  private final KakaoOAuthConfig config;
+  private final RestTemplate restTemplate = new RestTemplate();
+  private final UserAuthService userAuthService;
+
+  @Override
+  public OAuthURLRes getLoginUrl() {
+    String uriString = UriComponentsBuilder.fromHttpUrl("https://kauth.kakao.com/oauth/authorize")
+        .queryParam("client_id", config.getClientId())
+        .queryParam("redirect_uri", config.getRedirectUri())
+        .queryParam("response_type", "code")
+        .queryParam("scope", config.getScope())
+        .build().toUriString();
+    return new OAuthURLRes(uriString);
+  }
+
+  @Override
+  public String loginWithCode(String code) {
+    String accessToken = getAccessToken(code);
+    KakaoProfileResponse userInfo = getUserInfo(accessToken);
+    UserLoginRes login;
+
+    try {
+      login = userAuthService.login(OAuthProfileConverter.profileToLoginReq(userInfo));
+    } catch (ApplicationException e) {
+      userAuthService.signup(OAuthProfileConverter.profileToSignupReq(userInfo));
+      login = userAuthService.login(OAuthProfileConverter.profileToLoginReq(userInfo));
+    }
+
+    return UriComponentsBuilder.fromHttpUrl("encore://oauth")
+        .queryParam("token", login.accessToken())
+        .queryParam("isAgreedRequiredTerm", login.isAgreedRequiredTerm())
+        .queryParam("isActivePenalty", login.isActivePenalty())
+        .build().toUriString();
+  }
+
+  private String getAccessToken(String code) {
+    // 1. Access Token 요청
+    HttpHeaders tokenHeaders = new HttpHeaders();
+    tokenHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+    MultiValueMap<String, String> tokenParams = new LinkedMultiValueMap<>();
+    tokenParams.add("grant_type", "authorization_code");
+    tokenParams.add("client_id", config.getClientId());
+    tokenParams.add("redirect_uri", config.getRedirectUri());
+    tokenParams.add("code", code);
+
+    HttpEntity<?> tokenRequest = new HttpEntity<>(tokenParams, tokenHeaders);
+    ResponseEntity<Map> tokenResponse = restTemplate.postForEntity(
+        "https://kauth.kakao.com/oauth/token", tokenRequest, Map.class
+    );
+
+    if (!tokenResponse.getStatusCode().is2xxSuccessful()) {
+      throw new RuntimeException("카카오 access token 요청 실패");
+    }
+
+    return (String) Objects.requireNonNull(tokenResponse.getBody()).get("access_token");
+  }
+
+  private KakaoProfileResponse getUserInfo(String accessToken) {
+    // 2. 사용자 정보 요청
+    HttpHeaders profileHeaders = new HttpHeaders();
+    profileHeaders.setBearerAuth(accessToken);
+
+    HttpEntity<?> profileRequest = new HttpEntity<>(profileHeaders);
+    ResponseEntity<KakaoProfileResponse> profileResponse = restTemplate.exchange(
+        "https://kapi.kakao.com/v2/user/me", HttpMethod.GET, profileRequest,
+        KakaoProfileResponse.class
+    );
+
+    return profileResponse.getBody();
+  }
+}

--- a/src/main/java/encore/server/domain/user/service/oauth/OAuthLoginService.java
+++ b/src/main/java/encore/server/domain/user/service/oauth/OAuthLoginService.java
@@ -1,0 +1,8 @@
+package encore.server.domain.user.service.oauth;
+
+import encore.server.domain.user.dto.response.OAuthURLRes;
+
+public interface OAuthLoginService {
+  OAuthURLRes getLoginUrl();
+  String loginWithCode(String code);
+}

--- a/src/main/java/encore/server/global/config/oauth/GoogleOAuthConfig.java
+++ b/src/main/java/encore/server/global/config/oauth/GoogleOAuthConfig.java
@@ -1,0 +1,17 @@
+package encore.server.global.config.oauth;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@ConfigurationProperties(prefix = "google")
+@Component
+@Getter
+@Setter
+public class GoogleOAuthConfig {
+  private String clientId;
+  private String clientSecret;
+  private String redirectUri;
+  private String scope;
+}

--- a/src/main/java/encore/server/global/config/oauth/KakaoOAuthConfig.java
+++ b/src/main/java/encore/server/global/config/oauth/KakaoOAuthConfig.java
@@ -1,0 +1,16 @@
+package encore.server.global.config.oauth;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "kakao")
+@Getter
+@Setter
+public class KakaoOAuthConfig {
+  private String clientId;
+  private String redirectUri;
+  private String scope;
+}

--- a/src/main/java/encore/server/global/config/oauth/OAuthLoginServiceConfig.java
+++ b/src/main/java/encore/server/global/config/oauth/OAuthLoginServiceConfig.java
@@ -1,0 +1,24 @@
+package encore.server.global.config.oauth;
+
+import encore.server.domain.user.enumerate.AuthProvider;
+import encore.server.domain.user.service.oauth.GoogleOAuthService;
+import encore.server.domain.user.service.oauth.KakaoOAuthService;
+import encore.server.domain.user.service.oauth.OAuthLoginService;
+import java.util.Map;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OAuthLoginServiceConfig {
+
+  @Bean
+  public Map<AuthProvider, OAuthLoginService> loginServices(
+      KakaoOAuthService kakao,
+      GoogleOAuthService google) {
+
+    return Map.of(
+        AuthProvider.KAKAO, kakao,
+        AuthProvider.GOOGLE, google
+    );
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #44 

## 📝작업 내용
spring oauth2.0 라이브러리 사용 플로우에서 카카오, Google 로그인에 대해 OAuth2.0을 사용한 소셜로그인 직접 구현으로 변경.
ios 앱에서 사용 가능하도록 기존 2단계 요청에서 1단계로 변경하고, 마지막에 리다이렉트 하는 것으로 변경
https://www.notion.so/its-time/230c706af83d80bb8dcfdebd137b4d8f

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
> Apple로그인의 경우 비용 문제로 논의가 필요합니다
