### PR TITLE
#118 Fix: OAuth 로그인 리디렉트 버그 수정

### DIFF
--- a/src/main/java/encore/server/domain/user/service/oauth/GoogleOAuthService.java
+++ b/src/main/java/encore/server/domain/user/service/oauth/GoogleOAuthService.java
@@ -55,7 +55,7 @@ public class GoogleOAuthService implements OAuthLoginService {
       login = userAuthService.login(OAuthProfileConverter.profileToLoginReq(userInfo));
     }
 
-    return UriComponentsBuilder.fromHttpUrl("encore://oauth")
+    return UriComponentsBuilder.fromUriString("encore://oauth")
         .queryParam("token", login.accessToken())
         .queryParam("isAgreedRequiredTerm", login.isAgreedRequiredTerm())
         .queryParam("isActivePenalty", login.isActivePenalty())

--- a/src/main/java/encore/server/domain/user/service/oauth/KakaoOAuthService.java
+++ b/src/main/java/encore/server/domain/user/service/oauth/KakaoOAuthService.java
@@ -53,7 +53,7 @@ public class KakaoOAuthService implements OAuthLoginService {
       login = userAuthService.login(OAuthProfileConverter.profileToLoginReq(userInfo));
     }
 
-    return UriComponentsBuilder.fromHttpUrl("encore://oauth")
+    return UriComponentsBuilder.fromUriString("encore://oauth")
         .queryParam("token", login.accessToken())
         .queryParam("isAgreedRequiredTerm", login.isAgreedRequiredTerm())
         .queryParam("isActivePenalty", login.isActivePenalty())


### PR DESCRIPTION
UriComponentsBuilder.fromhttpUriString() 에서 UriComponentsBuilder.fromUriString() 으로 메소드 교체 

## #️⃣연관된 이슈
> #118 

## 📝작업 내용
> OAuth 리디렉트 시 HttpUriString 메소드로 되어 있어 커스텀 스킴으로 리디렉트 되지 않는 문제 해결


